### PR TITLE
Upgrade ci and linting

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,9 +26,7 @@ jobs:
       run: rm -rf ./build
     - name: Run Linters and Formatters
       run: |
-        black --check .
-        mypy .
-        flake8 .
+        pre-commit run --all-files
     - name: Run Tests
       run: |
         pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install SuiteSparse (dependency for scikit-sparse)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,21 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-json
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/ambv/black
-    rev: 24.2.0
-    hooks:
-      - id: black
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.11.2
     hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         exclude: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@ If you discover a security vulnerability in this project, please follow the step
 
 ### For "non-critical" issues
 
-- **Alternative A:**  
+- **Alternative A:**
 Create a GitHub issue for the vulnerability. Avoid putting sensitive information in the issue.
 
-- **Alternative B:**  
+- **Alternative B:**
 Send an email to the projects maintainer at [berl@equinor.com](mailto:berl@equinor.com) describing the issue.
 
 ### For "critical" and time sensitive issues

--- a/graphite_maps/linear_regression.py
+++ b/graphite_maps/linear_regression.py
@@ -1,8 +1,8 @@
 import numpy as np
 import scipy.sparse as sp
+from scipy.integrate import quad
 from scipy.sparse import spmatrix
 from scipy.stats import chi2
-from scipy.integrate import quad
 from sklearn.linear_model import LassoCV
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
@@ -43,7 +43,7 @@ def linear_l1_regression(U, Y, verbose_level: int = 0):
     assert n == n_y, "Number of samples in U and Y must be the same"
 
     if verbose_level > 0:
-        print(f"Learning sparse linear map of shape {(m,p)}")
+        print(f"Learning sparse linear map of shape {(m, p)}")
 
     scaler_u = StandardScaler()
     U_scaled = scaler_u.fit_transform(U)
@@ -53,17 +53,13 @@ def linear_l1_regression(U, Y, verbose_level: int = 0):
 
     # Loop over features
     i_H, j_H, values_H = [], [], []
-    for j in tqdm(
-        range(m), desc="Learning sparse linear map for each response"
-    ):
+    for j in tqdm(range(m), desc="Learning sparse linear map for each response"):
         y_j = Y_scaled[:, j]
 
         # Learn individual regularization and fit
         eps = 1e-3
         max_iter = 10000
-        model_cv = LassoCV(
-            cv=10, fit_intercept=False, max_iter=max_iter, eps=eps
-        )
+        model_cv = LassoCV(cv=10, fit_intercept=False, max_iter=max_iter, eps=eps)
         model_cv.fit(U_scaled, y_j)
 
         # Extract coefficients
@@ -85,9 +81,9 @@ def linear_l1_regression(U, Y, verbose_level: int = 0):
 
     if verbose_level > 0:
         print(
-            f"Total elements: {m*p}\n"
+            f"Total elements: {m * p}\n"
             f"Non-zero elements: {H_sparse.nnz}\n"
-            f"Fraction of non-zeros: {H_sparse.nnz / (m*p)}"
+            f"Fraction of non-zeros: {H_sparse.nnz / (m * p)}"
         )
 
     return H_sparse
@@ -155,15 +151,12 @@ def boost_linear_regression(
         beta_estimate = coef_changes[best_feature]
 
         # adjust to loo estimates for coef_change
-        influence = calculate_influence(
-            X[:, best_feature], residuals, beta_estimate
-        )
+        influence = calculate_influence(X[:, best_feature], residuals, beta_estimate)
         beta_estimate_loo = beta_estimate - influence / n_samples
 
         # residuals_full = residuals - beta_estimate * X[:, best_feature]
         residuals_full_loo = (
-            residuals_loo
-            - learning_rate * beta_estimate_loo * X[:, best_feature]
+            residuals_loo - learning_rate * beta_estimate_loo * X[:, best_feature]
         )
 
         if mse(residuals_loo) < mse(residuals_full_loo):
@@ -235,7 +228,7 @@ def linear_boost_ic_regression(
     assert n == n_y, "Number of samples in U and Y must be the same"
 
     if verbose_level > 0:
-        print(f"Learning sparse linear map of shape {(m,p)}")
+        print(f"Learning sparse linear map of shape {(m, p)}")
 
     scaler_u = StandardScaler()
     U_scaled = scaler_u.fit_transform(U)
@@ -245,9 +238,7 @@ def linear_boost_ic_regression(
 
     # Loop over features
     i_H, j_H, values_H = [], [], []
-    for j in tqdm(
-        range(m), desc="Learning sparse linear map for each response"
-    ):
+    for j in tqdm(range(m), desc="Learning sparse linear map for each response"):
         y_j = Y_scaled[:, j]
 
         # Learn individual fit
@@ -277,9 +268,9 @@ def linear_boost_ic_regression(
 
     if verbose_level > 0:
         print(
-            f"Total elements: {m*p}\n"
+            f"Total elements: {m * p}\n"
             f"Non-zero elements: {H_sparse.nnz}\n"
-            f"Fraction of non-zeros: {H_sparse.nnz / (m*p)}"
+            f"Fraction of non-zeros: {H_sparse.nnz / (m * p)}"
         )
 
     return H_sparse
@@ -313,9 +304,9 @@ def residual_variance(
     R = response_residual(U, Y, H)
     unexplained_variance = np.var(R, axis=0)
 
-    assert unexplained_variance.shape == (
-        m,
-    ), "Number of variance components must match number of observations"
+    assert unexplained_variance.shape == (m,), (
+        "Number of variance components must match number of observations"
+    )
 
     if verbose_level > 0:
         print("Calculating unexplained variance")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,44 +1,13 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
-
-[tool.black]
-line-length = 79
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
-
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "-ra -q"
-testpaths = [
-    "tests",
-]
-
-[tool.mypy]
-files = "graphite_maps"
-python_version = 3.9
-show_error_codes = true
-pretty = true
-ignore_missing_imports = true
 
 [project]
 name = "graphite-maps"
 version = "0.1.0"
 description = "Ensemble based data assimilation learning graph informed triangular ensemble-to-posterior transport maps from data"
 authors = [{name = "Berent Lunde"}]
+requires-python = ">=3.10, <3.13"
 dependencies = [
     "matplotlib",
     "scipy",
@@ -54,10 +23,59 @@ include = ["graphite_maps*"]
 
 [project.optional-dependencies]
 dev = [
+    "pre-commit",
     "pytest",
-    "mypy",
-    "pylint",
-    "ruff",
-    "black",
-    "flake8",
 ]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = [
+    "tests",
+]
+
+[tool.mypy]
+files = "graphite_maps"
+python_version = 3.10
+show_error_codes = true
+pretty = true
+ignore_missing_imports = true
+
+[tool.ruff]
+src = ["graphite_maps"]
+line-length = 88
+exclude = ["docs"]
+
+[tool.ruff.lint]
+select = [
+    "W",     # pycodestyle
+    "I",     # isort
+    "B",     # flake-8-bugbear
+    "SIM",   # flake-8-simplify
+    "F",     # pyflakes
+    "PL",    # pylint
+    "NPY",   # numpy specific rules
+    "C4",    # flake8-comprehensions
+    "ASYNC", # flake8-async
+    "RUF",   # ruff specific rules
+    "UP",    # pyupgrade
+    "ICN",   # flake8-import-conventions
+    "PIE",   # flake8-pie
+]
+
+ignore = [
+    "PLW2901", # redefined-loop-name
+    "PLR2004", # magic-value-comparison
+    "PLR0915", # too-many-statements
+    "PLR0912", # too-many-branches
+    "PLR0911", # too-many-return-statements
+    "PLC2701", # import-private-name
+    "PLR0914", # too-many-locals
+    "PLR6301", # no-self-use
+    "PLW1641", # eq-without-hash
+    "PLR0904", # too-many-public-methods
+    "PLR1702", # too-many-nested-blocks
+]
+
+[tool.ruff.lint.pylint]
+max-args = 20

--- a/tests/test_precision_estimation.py
+++ b/tests/test_precision_estimation.py
@@ -1,8 +1,7 @@
 import numpy as np
-from scipy.sparse import diags
-from scipy.linalg import det
-
 from graphite_maps import precision_estimation as precest
+from scipy.linalg import det
+from scipy.sparse import diags
 
 
 def test_precision_graph_conversion():


### PR DESCRIPTION
Sets required python >= 3.10. 
Moves linting and formatting to pre-commit. 
Replaces black and flake8 with ruff.