### PR TITLE
Add build test publish pipeline

### DIFF
--- a/.github/workflows/build_and_test_linux.yml
+++ b/.github/workflows/build_and_test_linux.yml
@@ -1,0 +1,117 @@
+name: Build and test Linux
+
+on:
+ push:
+   branches:
+     - main
+   tags: "*"
+ pull_request:
+
+env:
+  UV_FROZEN: true         # https://docs.astral.sh/uv/configuration/environment/#uv_frozen
+
+jobs:
+  build-wheels-linux:
+    name: Build 🛞
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.11', '3.12' ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: build-wheels-linux
+        uses: docker://quay.io/pypa/manylinux2014_x86_64
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        with:
+          entrypoint: /bin/bash
+          args: '-c "sh wheel_build_scripts/build_wheels_linux.sh ${{ matrix.python-version }}"'
+
+      - name: Upload wheel as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Python ${{ matrix.python-version }} wheel
+          path: |
+            graphite*.whl
+
+  test-linux:
+    needs: [build-wheels-linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.11', '3.12' ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "Python ${{ matrix.python-version }} wheel"
+      - name: Install wheel
+        run: |
+          # Find the downloaded wheel file
+          wheel_file=$(find . -name "graphite*.whl" -print -quit)
+
+          echo "Found wheel file @ $wheel_file"
+
+          # Install the wheel
+          pip install "$wheel_file"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run EnIF unit tests
+        run: |
+          python -m pip install pytest
+          pytest
+
+      - name: Clone & install ERT repo
+        run: |
+          git clone --branch enif-in-ert-no-sksparse --single-branch https://github.com/yngve-sk/ert
+          echo "install enif branch  (point to eqn when enif merged in)"
+          cd ert
+          sudo apt-get install libegl1
+          pip install ".[dev]"
+          pip uninstall scikit-sparse
+
+      - name: Run ERT EnIF tests
+        run: |
+          pytest -k "enif"
+
+      - name: Run ERT poly example with EnIF
+        run: |
+          ert ensemble_information_filter ert/test-data/ert/poly_example/poly.ert
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-wheels-linux, test-linux]
+    permissions:
+      id-token: write
+
+    # If this is a tagged release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
+    steps:
+      - name: Get wheels
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Move to dist/
+        run: |
+          mkdir dist
+          find artifacts -name "*.whl" -exec mv '{}' dist/ \;
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.github/workflows/build_and_test_macos.yml
+++ b/.github/workflows/build_and_test_macos.yml
@@ -1,0 +1,141 @@
+name: Build and test MacOS
+
+on:
+ push:
+   branches:
+     - main
+   tags: "*"
+ pull_request:
+env:
+  UV_FROZEN: true         # https://docs.astral.sh/uv/configuration/environment/#uv_frozen
+
+jobs:
+  build-wheels-macos:
+    strategy:
+      matrix:
+        python-version: [ '3.11', '3.12' ]
+      fail-fast: false
+    runs-on: macos-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build the wheel
+        run: |
+          echo "Installing suite-sparse..."
+          brew install suite-sparse
+          suitesparse_dir="$(brew --prefix suitesparse)"
+          suite_sparse_inc="$suitesparse_dir/include/suitesparse"
+          suite_sparse_lib="$suitesparse_dir/lib"
+
+          echo "suite_sparse_inc=$suite_sparse_inc"
+          echo "suite_sparse_lib=$suite_sparse_lib"
+
+          pip install --upgrade pip setuptools wheel
+          git clone --branch v0.4.15 --single-branch https://github.com/scikit-sparse/scikit-sparse
+
+          echo "Doing editable scikit-sparse install"
+          SUITESPARSE_INCLUDE_DIR=$suite_sparse_inc SUITESPARSE_LIBRARY_DIR=$suite_sparse_lib pip wheel -e scikit-sparse
+
+          echo "copying scikit-sparse/sksparse to graphite_maps/sksparse ..."
+          cp -r scikit-sparse/sksparse graphite_maps/sksparse
+
+          # Breaks the install, fixes the wheel
+          echo "adding wheel-only setup.py..."
+          mv wheel_build_scripts/setup_wheels_only.py setup.py
+          SUITESPARSE_INCLUDE_DIR=$suite_sparse_inc SUITESPARSE_LIBRARY_DIR=$suite_sparse_lib pip wheel .
+
+          wheel_file=$(find . -name "graphite*.whl")
+          echo "wheel is at @wheel_file"
+          pip install delocate
+          delocate-wheel $(find . -name "graphite*.whl")
+          echo "Delocated wheel @$wheel_file successfully"
+      - name: Upload wheel as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Python ${{ matrix.python-version }} wheel
+          path: |
+            graphite*.whl
+
+  test-macos:
+    needs: [build-wheels-macos]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.11', '3.12' ]
+    runs-on: macos-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "Python ${{ matrix.python-version }} wheel"
+
+      - name: Install wheel
+        run: |
+          # Find the downloaded wheel file
+          wheel_file=$(find . -name "graphite*.whl" -print -quit)
+
+          echo "Found wheel file @ $wheel_file"
+
+          # Install the wheel
+          pip install "$wheel_file"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run EnIF unit tests
+        run: |
+          python -m pip install pytest
+          pytest
+
+      - name: Clone & install ERT repo
+        run: |
+          git clone --branch enif-in-ert-no-sksparse --single-branch https://github.com/yngve-sk/ert
+          echo "install enif branch  (point to eqn when enif merged in)"
+          cd ert
+          pip install ".[dev]"
+          pip uninstall scikit-sparse
+
+      - name: Run ERT EnIF tests
+        run: |
+          pytest -k "enif"
+
+      - name: Run ERT poly example with EnIF
+        run: |
+          ert ensemble_information_filter ert/test-data/ert/poly_example/poly.ert
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-wheels-macos, test-macos]
+    permissions:
+      id-token: write
+
+    # If this is a tagged release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
+    steps:
+      - name: Get wheels
+        uses: actions/download-artifact@v4
+
+        with:
+          path: artifacts
+
+      - name: Move to dist/
+        run: |
+          mkdir dist
+          find artifacts -name "*.whl" -exec mv '{}' dist/ \;
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]  # Install package along with dev dependencies
+        pip install scikit-sparse
     - name: Clean up build directory
       run: rm -rf ./build
     - name: Run Linters and Formatters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [build-system]
-requires = ["setuptools>=42", "numpy"]
+requires = ["setuptools>=42", "numpy", "setuptools_scm>=8.1"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "graphite_maps/version.py"
 
 [project]
 name = "graphite-maps"
-version = "0.1.0"
 description = "Ensemble based data assimilation learning graph informed triangular ensemble-to-posterior transport maps from data"
 authors = [{name = "Berent Lunde"}]
 requires-python = ">=3.10, <3.13"
@@ -15,6 +17,7 @@ dependencies = [
     "networkx",
     "tqdm",
 ]
+dynamic = ["version"]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -24,7 +27,7 @@ include = ["graphite_maps*"]
 dev = [
     "pre-commit",
     "pytest",
-    "scikit-sparse"
+    "scikit-sparse" # Must be installed with linking towards libsuitesparse
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42"]
+requires = ["setuptools>=42", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,7 +12,6 @@ dependencies = [
     "matplotlib",
     "scipy",
     "scikit-learn",
-    "scikit-sparse",
     "networkx",
     "tqdm",
 ]
@@ -25,6 +24,7 @@ include = ["graphite_maps*"]
 dev = [
     "pre-commit",
     "pytest",
+    "scikit-sparse"
 ]
 
 [tool.pytest.ini_options]

--- a/wheel_build_scripts/build_wheels_linux.sh
+++ b/wheel_build_scripts/build_wheels_linux.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+  echo "Please provide a Python version as an argument (e.g., 3.10)"
+  exit 1
+fi
+
+INSTALL_DIR=/github/workspace/deps_build
+
+pushd /tmp
+
+python_exec=$(which python$1)
+$python_exec -m venv myvenv
+source ./myvenv/bin/activate
+
+yum install -y suitesparse-devel
+python -m pip install --upgrade pip
+pip install --upgrade setuptools wheel auditwheel
+
+git clone --branch v0.4.15 --single-branch https://github.com/scikit-sparse/scikit-sparse
+LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH pip install --editable scikit-sparse
+
+popd
+echo "copying sksparse into graphite_maps/sksparse"
+cp -r /tmp/scikit-sparse/sksparse graphite_maps/sksparse
+
+# Breaks the install, fixes the wheel
+echo "adding wheel-only setup.py..."
+mv wheel_build_scripts/setup_wheels_only.py setup.py
+
+echo "Making wheel..."
+LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH pip wheel .
+echo "Done making wheel"
+
+pip install auditwheel
+wheel_path=$(find . -name "graphite*.whl")
+auditwheel repair $wheel_path -w fixed_wheel
+fixed_wheel_path=$(find fixed_wheel -name "*.whl")
+
+echo "Replacing broken wheel @ $wheel_path with fixed wheel @ $fixed_wheel_path"
+rm $wheel_path
+mv $fixed_wheel_path $wheel_path

--- a/wheel_build_scripts/setup_wheels_only.py
+++ b/wheel_build_scripts/setup_wheels_only.py
@@ -1,0 +1,32 @@
+import os
+
+import numpy as np
+from setuptools import Extension, setup
+
+INCLUDE_DIRS = [
+    # Debian's suitesparse-dev installs to
+    np.get_include(),
+    "/usr/include/suitesparse",
+]
+LIBRARY_DIRS = []
+
+user_include_dir = os.getenv("SUITESPARSE_INCLUDE_DIR")
+user_library_dir = os.getenv("SUITESPARSE_LIBRARY_DIR")
+if user_include_dir:
+    INCLUDE_DIRS.append(user_include_dir)
+
+if user_library_dir:
+    LIBRARY_DIRS.append(user_library_dir)
+
+# Force platform-specific!
+setup(
+    ext_modules=[
+        Extension(
+            "sksparse.cholmod",
+            ["graphite_maps/sksparse/cholmod.pyx"],
+            include_dirs=INCLUDE_DIRS,
+            library_dirs=LIBRARY_DIRS,
+            libraries=["cholmod"],
+        )
+    ],
+)


### PR DESCRIPTION
For macos and linux. Set up some extra scaffolding for when we will pack scikit-sparse into the wheel.

Approach (so far):
1. Install libsuitesparse
2. Download and editable install scikit-sparse
3. Copy scikit-sparse/sksparse into graphite_maps/graphite_maps
4. Rename `setup_wheels_only.py` to `setup.py` (having it there will mess up install for local development, but make wheels include the correct external stuff)
5. build the wheel