### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/build_and_test_linux.yml
+++ b/.github/workflows/build_and_test_linux.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.11', '3.12' ]
+        python-version: [ '3.11', '3.12', '3.13' ]
     runs-on: ubuntu-latest
 
     steps:
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.11', '3.12' ]
+        python-version: [ '3.11', '3.12', '3.13' ]
     runs-on: ubuntu-latest
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version_scheme = "only-version"
 name = "graphite-maps"
 description = "Ensemble based data assimilation learning graph informed triangular ensemble-to-posterior transport maps from data"
 authors = [{name = "Berent Lunde"}]
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.14"
 dependencies = [
     "matplotlib",
     "scipy",


### PR DESCRIPTION
Note that the Ert tests cannot pass, since Ert cannot support Python 3.13 because it depends on graphite-maps supporting it.