### PR TITLE
Do not depend on Ert tests for PyPI deploy

### DIFF
--- a/.github/workflows/build_and_test_linux.yml
+++ b/.github/workflows/build_and_test_linux.yml
@@ -86,6 +86,37 @@ jobs:
           python -m pip install pytest
           pytest
 
+  test-ert:
+    needs: [build-wheels-linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.11', '3.12', '3.13' ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "Python ${{ matrix.python-version }} wheel"
+      - name: Install wheel
+        run: |
+          # Find the downloaded wheel file
+          wheel_file=$(find . -name "graphite*.whl" -print -quit)
+
+          echo "Found wheel file @ $wheel_file"
+
+          # Install the wheel
+          pip install "$wheel_file"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Clone & install ERT repo
         run: |
           git clone --branch enif-in-ert-no-sksparse --single-branch https://github.com/yngve-sk/ert


### PR DESCRIPTION
Otherwise we are deadlocked, as Ert cannot progress to Python 3.13 due to no 3.13 wheels for graphite-maps on PyPI