### PR TITLE
Replace iterative optimizer with closed-form row solver for precision estimation

### DIFF
--- a/docs/source/ClosedFormRowSolver.md
+++ b/docs/source/ClosedFormRowSolver.md
@@ -1,0 +1,138 @@
+# Closed-form row solver
+
+This document records the derivation of the analytic row solve used by
+`graphite_maps.precision_estimation.solve_row_closed_form`.
+
+## Objective
+
+To estimate the precision matrix, we solve for the non-zero coefficients in each
+row of the lower triangular factor $C$. For a given row, the objective function
+is
+
+$$
+f(c) = \frac{1}{2}\lVert U_{\mathrm{reduced}} c \rVert_2^2 - n\log(c_d) + \frac{\lambda}{2}\lVert c_{\mathrm{off}}\rVert_2^2,
+$$
+
+where
+
+- $c = [c_{\mathrm{off}}, c_d]$ is the vector of non-zero coefficients for the
+  row,
+- $c_d > 0$ is the diagonal coefficient,
+- $c_{\mathrm{off}}$ are the off-diagonal coefficients,
+- $U_{\mathrm{reduced}}$ is the data matrix restricted to the non-zero columns
+  of the row,
+- $\lambda$ is the L2 regularization weight, and
+- $n$ is the number of samples.
+
+## Why a closed form exists
+
+A direct iterative approach would minimize this objective numerically row by
+row. The current implementation instead uses a closed-form solve. This is
+possible because the problem decouples row by row and contains only a single
+logarithmic term, $-n\log(c_d)$, involving the diagonal coefficient.
+
+The key idea is to factor out $c_d$ and reparameterize the off-diagonal
+coefficients so the remaining problem becomes ridge regression plus a
+one-dimensional solve for the diagonal term.
+
+## Derivation
+
+First split the matrix-vector product by columns:
+
+$$
+U_{\mathrm{reduced}} c = U_{\mathrm{reduced}}[:, :-1] c_{\mathrm{off}} + U_{\mathrm{reduced}}[:, -1] c_d.
+$$
+
+Now define
+
+$$
+X = U_{\mathrm{reduced}}[:, :-1], \qquad z = U_{\mathrm{reduced}}[:, -1],
+$$
+
+so that
+
+$$
+U_{\mathrm{reduced}} c = X c_{\mathrm{off}} + z c_d.
+$$
+
+To expose the quadratic ridge-regression structure, reparameterize the
+off-diagonal coefficients by factoring out $c_d$:
+
+$$
+\beta = -\frac{c_{\mathrm{off}}}{c_d}.
+$$
+
+Then $X c_{\mathrm{off}} + z c_d = c_d (z - X\beta)$, and the objective becomes
+
+$$
+f(\beta, c_d) = \frac{1}{2} c_d^2 \lVert z - X\beta\rVert_2^2 - n\log(c_d) + \frac{\lambda}{2} c_d^2 \lVert\beta\rVert_2^2.
+$$
+
+For any fixed $c_d > 0$, we can factor out $\frac{1}{2} c_d^2$ from the terms
+involving $\beta$. Because scaling by a positive constant and adding a constant,
+$-n\log(c_d)$, does not change the location of the minimum, minimizing over
+$\beta$ is equivalent to minimizing the inner quadratic form
+$\lVert z - X\beta\rVert_2^2 + \lambda \lVert\beta\rVert_2^2$. This gives the
+standard ridge-regression normal equations:
+
+$$
+(X^\top X + \lambda I) \tilde\beta = X^\top z.
+$$
+
+Denote $\tilde\beta$ as this optimal solution. We can then evaluate the
+quadratic part of the objective at $\tilde\beta$. Let
+
+$$
+\alpha = \lVert z - X\tilde\beta\rVert_2^2 + \lambda \lVert\tilde\beta\rVert_2^2.
+$$
+
+By factoring out $\frac{1}{2} c_d^2$ from the original objective function, we
+get
+
+$$
+f(\beta, c_d) = \frac{1}{2} c_d^2 \left( \lVert z - X\beta\rVert_2^2 + \lambda \lVert\beta\rVert_2^2 \right) - n\log(c_d).
+$$
+
+Substituting the optimal $\tilde\beta$ back into this equation, the term in
+parentheses is exactly our definition of $\alpha$. This reduces the objective
+to a function of $c_d$ alone:
+
+$$
+f(c_d) = \frac{1}{2} \alpha c_d^2 - n\log(c_d).
+$$
+
+Taking the derivative with respect to $c_d$ and setting it to zero yields the
+first-order condition
+
+$$
+f'(c_d) = \alpha c_d - \frac{n}{c_d} = 0,
+$$
+
+which gives the optimal diagonal coefficient:
+
+$$
+c_d^2 = \frac{n}{\alpha} \implies c_d = \sqrt{\frac{n}{\alpha}}.
+$$
+
+Finally, we recover the off-diagonal coefficients using our reparameterization:
+
+$$
+c_{\mathrm{off}} = -c_d \tilde\beta.
+$$
+
+This matches the implementation steps in `solve_row_closed_form`.
+
+## Simplification of $\alpha$ for implementation
+
+While the simplification of $\alpha$ is not strictly needed for the derivation,
+it provides a more efficient way to compute $\alpha$ in the implementation:
+
+$$
+\begin{aligned}
+\alpha &= z^\top z - 2 z^\top X \tilde\beta + \tilde\beta^\top X^\top X \tilde\beta + \lambda \tilde\beta^\top \tilde\beta \\
+       &= z^\top z - 2 z^\top X \tilde\beta + \tilde\beta^\top (X^\top X + \lambda I) \tilde\beta \\
+       &= z^\top z - 2 z^\top X \tilde\beta + \tilde\beta^\top (X^\top z) \\
+       &= z^\top z - z^\top X \tilde\beta \\
+       &= \lVert z\rVert_2^2 - (X^\top z)^\top \tilde\beta.
+\end{aligned}
+$$

--- a/graphite_maps/precision_estimation.py
+++ b/graphite_maps/precision_estimation.py
@@ -4,7 +4,6 @@ import networkx as nx
 import numpy as np
 import scipy.sparse as sp
 from numpy.typing import NDArray
-from scipy.optimize import minimize
 from scipy.sparse import csc_array, tril
 from sksparse.cholmod import Factor, cholesky
 from tqdm import tqdm
@@ -233,15 +232,69 @@ def hessian(
     return H
 
 
+def solve_row_closed_form(
+    U_reduced: np.ndarray,
+    lambda_l2: float,
+) -> tuple[np.ndarray, float]:
+    """
+    Closed-form minimizer for one row objective.
+
+    This function computes the exact analytic solution for the row-wise objective
+    function, avoiding the need for iterative numerical optimization.
+    For the full mathematical derivation of this closed-form solution,
+    see ``docs/source/ClosedFormRowSolver.md``.
+
+    Parameters
+    ----------
+    U_reduced : np.ndarray
+        Reduced data matrix with columns corresponding to non-zero entries
+        in row ``k`` ordered as ``[..., k]``.
+    lambda_l2 : float
+        L2 regularization weight on off-diagonal coefficients.
+
+    Returns
+    -------
+    tuple[np.ndarray, float]
+        Off-diagonal coefficients and positive diagonal coefficient.
+
+    Raises
+    ------
+    ValueError
+        If numerical degeneracy prevents a valid positive diagonal estimate.
+    """
+    n, n_cols = U_reduced.shape
+    z = U_reduced[:, -1]
+
+    if n_cols == 1:
+        alpha = float(np.dot(z, z))
+        if alpha <= 0.0:
+            raise ValueError("Degenerate row: non-positive alpha in closed-form solve")
+        diag_value = np.sqrt(n / alpha)
+        return np.empty(0, dtype=U_reduced.dtype), float(diag_value)
+
+    X = U_reduced[:, :-1]
+    gram = X.T @ X
+    np.fill_diagonal(gram, np.diag(gram) + lambda_l2)
+    rhs = X.T @ z
+
+    beta_tilde = np.linalg.solve(gram, rhs)
+    alpha = float(np.dot(z, z) - np.dot(rhs, beta_tilde))
+    if alpha <= 0.0:
+        raise ValueError("Degenerate row: non-positive alpha in closed-form solve")
+
+    diag_value = np.sqrt(n / alpha)
+    off_diag = -diag_value * beta_tilde
+    return off_diag, float(diag_value)
+
+
 def optimize_sparse_affine_kr_map(
     U: NDArray[np.floating],
     G: nx.Graph,
-    optimization_method: str = "L-BFGS-B",
     verbose_level: int = 0,
     use_tqdm: bool = True,
 ) -> csc_array:
     """Optimize the affine Knothe-Rosenblatt (KR) map with standard Gaussian
-    reference and l2-regularized dependence.
+    reference and l2-regularized dependence using the closed-form row solve.
 
     Parameters
     ----------
@@ -273,28 +326,19 @@ def optimize_sparse_affine_kr_map(
     for k in loop_function:
         non_zero_indices = [j for j in G.neighbors(k) if j < k] + [k]
 
-        # Extract the non-zero elements of C_k
-        C_k_reduced = C_full[k, non_zero_indices].toarray().ravel()
-
         # Extract the reduced version of U
         U_reduced = U[:, non_zero_indices]
 
         # Optimization for reduced C_k
         lambda_l2_aic = 2.0 * len(non_zero_indices)
-        res = minimize(
-            fun=objective_function,
-            x0=C_k_reduced,
-            args=(U_reduced, lambda_l2_aic),
-            method=optimization_method,
-            jac=gradient,
-            # hess=hessian,
-            tol=1e-12,
-            options={"gtol": 1e-9},
+        off_diag, diag_value = solve_row_closed_form(
+            U_reduced=U_reduced,
+            lambda_l2=lambda_l2_aic,
         )
 
-        # Update the full C_k with optimized values
-        C_full[k, non_zero_indices] = res.x
-        C_full[k, k] = np.exp(C_full[k, k])  # res.x learns log diag
+        if len(non_zero_indices) > 1:
+            C_full[k, non_zero_indices[:-1]] = off_diag
+        C_full[k, k] = diag_value
 
     # Convert to csc_array for efficient storage and arithmetic operations
     return C_full.tocsc()
@@ -361,7 +405,6 @@ def fit_precision_cholesky_approximate(
     U: NDArray[np.floating],
     G: nx.Graph,
     neighbourhood_expansion: int = 2,
-    optimization_method: str = "L-BFGS-B",
     verbose_level: int = 0,
     use_tqdm: bool = True,
 ) -> csc_array:
@@ -408,7 +451,6 @@ def fit_precision_cholesky_approximate(
     C = optimize_sparse_affine_kr_map(
         U=U,
         G=G_expanded,
-        optimization_method=optimization_method,
         verbose_level=verbose_level - 1,
         use_tqdm=use_tqdm,
     )

--- a/tests/test_precision_estimation.py
+++ b/tests/test_precision_estimation.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import scipy as sp
 from graphite_maps import precision_estimation as precest
+from scipy.optimize import minimize
 
 
 def test_objective_twice():
@@ -24,6 +25,34 @@ def test_objective_twice():
         rng=rng,
     )
     assert rmse <= 0.002
+
+
+def test_closed_form_matches_iterative_solver():
+    """Closed-form row solver agrees with the iterative (L-BFGS-B) solution."""
+    rng = np.random.default_rng(0)
+    n, n_cols = 200, 5
+    U_reduced = rng.normal(size=(n, n_cols))
+    lambda_l2 = 2.0 * n_cols
+
+    # Closed-form solution introduced in commit 864f430
+    off_diag_cf, diag_cf = precest.solve_row_closed_form(U_reduced, lambda_l2)
+
+    # Iterative reference solution (L-BFGS-B on the log-diagonal parametrisation)
+    x0 = np.zeros(n_cols)
+    res = minimize(
+        fun=precest.objective_function,
+        x0=x0,
+        args=(U_reduced, lambda_l2),
+        method="L-BFGS-B",
+        jac=precest.gradient,
+        tol=1e-12,
+        options={"gtol": 1e-9},
+    )
+    off_diag_iter = res.x[:-1]
+    diag_iter = np.exp(res.x[-1])
+
+    np.testing.assert_allclose(off_diag_cf, off_diag_iter, rtol=1e-4, atol=1e-6)
+    np.testing.assert_allclose(diag_cf, diag_iter, rtol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace scipy.optimize.minimize (L-BFGS-B) with an analytic closed-form
solution in _solve_row_closed_form. The row-wise objective decouples into
ridge regression for off-diagonal coefficients and a 1D solve for the
diagonal, eliminating the need for iterative numerical optimization.

Key changes:
- Add _solve_row_closed_form using ridge normal equations + analytic diagonal
- Remove optimization_method parameter from public API functions
- Remove scipy.optimize dependency
- Store diagonal directly instead of learning log-diagonal
- Add mathematical derivation docs in docs/source/ClosedFormRowSolver.md

## Code used for benchmarking

```python
"""Benchmark iterative vs closed-form sparse affine KR map solvers.

Example output:

Benchmarking optimize_sparse_affine_kr_map
Settings: n_samples=100
       p |   iterative (s) | closed-form (s) | speedup (x)
----------------------------------------------------------
    1000 |        0.393801 |        0.055159 |       7.14x
    9702 |        3.724479 |        0.487516 |       7.64x
   99452 |       40.286785 |        5.130263 |       7.85x

"""

from __future__ import annotations

import itertools
import time
from typing import Literal

import gstools as gs
import networkx as nx
import numpy as np
from graphite_maps.precision_estimation import optimize_sparse_affine_kr_map


def sample_grf_cube(n_samples: int, px: int, py: int, pz: int) -> np.ndarray:
    """Sample Gaussian random fields on a 3D structured grid."""
    model = gs.Exponential(dim=3, var=1.0, len_scale=min(px, py, pz) / 4.0)
    srf = gs.SRF(model)
    grid = [np.arange(px), np.arange(py), np.arange(pz)]

    U = np.empty((n_samples, px * py * pz), dtype=float)
    for i in range(n_samples):
        field = srf.structured(grid)
        U[i] = np.asarray(field, dtype=float).ravel()
    return U


def create_flattened_cube_graph(px: int, py: int, pz: int) -> nx.Graph:
    """Copied from ert.
    graph created with nodes numbered from 0 to px*py*pz
    corresponds to the "vectorization" or flattening of
    a 3D cube with shape (px,py,pz) in the same way as
    reshaping such a cube into a one-dimensional array.
    The indexing scheme used to create the graph reflects
    this flattening process"""

    G = nx.Graph()
    for x, y, z in itertools.product(range(px), range(py), range(pz)):
        # Flatten the 3D index to a single index
        index = x * py * pz + y * pz + z

        # Connect to the right neighbor (y-direction)
        if y < py - 1:
            G.add_edge(index, index + pz)

        # Connect to the bottom neighbor (x-direction)
        if x < px - 1:
            G.add_edge(index, index + py * pz)

        # Connect to the neighbor in front (z-direction)
        if z < pz - 1:
            G.add_edge(index, index + 1)

    return G


def run_single_solver(
    U: np.ndarray,
    graph: nx.Graph,
    solver: Literal["iterative", "closed_form"],
) -> float:
    """Run one solver and return seconds."""
    start = time.perf_counter()
    _ = optimize_sparse_affine_kr_map(
        U,
        graph,
        solver=solver,
        use_tqdm=False,
    )
    return time.perf_counter() - start


def main() -> None:
    grid_shapes = ((10, 10, 10), (21, 21, 22), (46, 46, 47))
    n_samples = 100

    print("Benchmarking optimize_sparse_affine_kr_map")
    print(f"Settings: n_samples={n_samples}")

    headers = ["p", "iterative (s)", "closed-form (s)", "speedup (x)"]
    print(f"{headers[0]:>8} | {headers[1]:>15} | {headers[2]:>15} | {headers[3]:>11}")
    print("-" * 58)

    speedups = []
    for px, py, pz in grid_shapes:
        p = px * py * pz
        U = sample_grf_cube(n_samples, px, py, pz)
        graph = create_flattened_cube_graph(px, py, pz)

        iter_time = run_single_solver(U, graph, "iterative")
        closed_time = run_single_solver(U, graph, "closed_form")
        speedup = iter_time / closed_time
        speedups.append(speedup)

        print(f"{p:8d} | {iter_time:15.6f} | {closed_time:15.6f} | {speedup:10.2f}x")

    print(
        "\nSummary: "
        f"closed-form is {min(speedups):.2f}x to {max(speedups):.2f}x faster "
        "than iterative on these cases."
    )


if __name__ == "__main__":
    main()

```