### PR TITLE
Fix memory explosion in parallel linear boost regression

### DIFF
--- a/graphite_maps/linear_regression.py
+++ b/graphite_maps/linear_regression.py
@@ -204,19 +204,22 @@ def boost_linear_regression(
 def _fit_single_response_boost(
     j: int,
     U_scaled: NDArray[np.floating],
-    Y_scaled: NDArray[np.floating],
+    y_j: NDArray[np.floating],
     learning_rate: float,
     effective_dimension: int | None,
-) -> tuple[int, NDArray[np.floating]]:
-    """Fit boosted regression for a single response column."""
-    y_j = Y_scaled[:, j]
+) -> tuple[int, NDArray[np.integer], NDArray[np.floating]]:
+    """Fit boosted regression for a single response column.
+
+    Returns sparse representation (j, nonzero_indices, nonzero_values)
+    """
     coefficients_j = boost_linear_regression(
         U_scaled,
         y_j,
         learning_rate=learning_rate,
         effective_dimension=effective_dimension,
     )
-    return j, coefficients_j
+    nonzero = coefficients_j.nonzero()[0]
+    return j, nonzero, coefficients_j[nonzero]
 
 
 def linear_boost_ic_regression(
@@ -243,7 +246,7 @@ def linear_boost_ic_regression(
     Y : np.ndarray
         2D array of responses with shape (n, m).
     n_jobs : int, optional
-        Number of parallel jobs. Use -1 for all CPUs. Default is 1 (sequential).
+        Number of parallel jobs. Use -1 for all CPUs. Default is -1.
 
     Returns
     -------
@@ -270,25 +273,24 @@ def linear_boost_ic_regression(
     # Fit responses in parallel
     results = Parallel(n_jobs=n_jobs)(
         delayed(_fit_single_response_boost)(
-            j, U_scaled, Y_scaled, learning_rate, effective_dimension
+            j, U_scaled, Y_scaled[:, j], learning_rate, effective_dimension
         )
         for j in tqdm(range(m), desc="Learning sparse linear map for each response")
     )
 
-    # Extract coefficients from results
+    # Assemble sparse matrix from results
     i_H, j_H, values_H = [], [], []
-    for j, coefficients_j in results:
-        for non_zero_ind in coefficients_j.nonzero()[0]:
-            i_H.append(j)
-            j_H.append(non_zero_ind)
-            values_H.append(
-                scaler_y.scale_[j]
-                * coefficients_j[non_zero_ind]
-                / scaler_u.scale_[non_zero_ind]
-            )
+    for j, nonzero_indices, nonzero_values in results:
+        k = len(nonzero_indices)
+        i_H.append(np.full(k, j, dtype=np.intp))
+        j_H.append(nonzero_indices)
+        values_H.append(
+            scaler_y.scale_[j] * nonzero_values / scaler_u.scale_[nonzero_indices]
+        )
 
     H_sparse = sp.csc_matrix(
-        (np.array(values_H), (np.array(i_H), np.array(j_H))), shape=(m, p)
+        (np.concatenate(values_H), (np.concatenate(i_H), np.concatenate(j_H))),
+        shape=(m, p),
     )
 
     # Assert shape of H_sparse

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -3,6 +3,7 @@ import time
 import numpy as np
 import pytest
 from graphite_maps.linear_regression import (
+    _fit_single_response_boost,
     boost_linear_regression,
     linear_boost_ic_regression,
 )
@@ -192,3 +193,20 @@ def test_that_rowwise_fitting_requires_independent_features():
         f"Expected larger mismatch with dependent features "
         f"(dep={diff_dep:.4f}, indep={diff_indep:.4f})"
     )
+
+
+def test_single_response_returns_sparse_representation():
+    """_fit_single_response_boost must return (j, nonzero_indices, nonzero_values),
+    not a full dense coefficient vector."""
+    rng = np.random.default_rng(42)
+    n, p = 50, 100
+    U_scaled = rng.standard_normal((n, p))
+    y_j = rng.standard_normal(n)
+
+    j = 0
+    col_idx, nonzero_indices, nonzero_values = _fit_single_response_boost(
+        j, U_scaled, y_j, learning_rate=0.5, effective_dimension=None
+    )
+    assert col_idx == j
+    assert nonzero_indices.shape == nonzero_values.shape
+    assert nonzero_values.size < p


### PR DESCRIPTION
- Sparsify coefficients inside _fit_single_response_boost before returning
- Pass only Y_scaled[:, j] per worker instead of the full Y_scaled matrix