### PR TITLE
Remove method residual_variance

### DIFF
--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -205,7 +205,9 @@ class EnIF:
                 U, Y, verbose_level=verbose_level - 1
             )
 
-        self.residual_variance(U, Y, verbose_level=verbose_level - 1)
+        self.unexplained_variance = lr.residual_variance(
+            U, Y, self.H, verbose_level=verbose_level - 1
+        )
 
     def pushforward_to_canonical(
         self, U: NDArray[np.floating], verbose_level: int = 0
@@ -248,20 +250,11 @@ class EnIF:
         if self.H is None:
             raise ValueError("H is not set.")
 
-        self.residual_variance(U, Y, verbose_level=verbose_level - 1)
-
-        return lr.response_residual(U, Y, self.H, verbose_level=verbose_level - 1)
-
-    def residual_variance(
-        self, U: NDArray[np.floating], Y: NDArray[np.floating], verbose_level: int = 0
-    ) -> None:
-        """Sets self.unexplained_variance from variance on residuals"""
-        if self.H is None:
-            raise ValueError("H is not set.")
-
         self.unexplained_variance = lr.residual_variance(
             U, Y, self.H, verbose_level=verbose_level - 1
         )
+
+        return lr.response_residual(U, Y, self.H, verbose_level=verbose_level - 1)
 
     def generate_observation_noise(
         self, n: int, seed: int | None = None, verbose_level: int = 0


### PR DESCRIPTION
residual_variance simply calls `lr.residual_variance` and sets an attribute. Might as well remove this "thin" method.