### PR TITLE
Migrate csc array api

### DIFF
--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -4,7 +4,7 @@ import networkx as nx
 import numpy as np
 import scipy as sp
 from numpy.typing import NDArray
-from scipy.sparse import diags, spmatrix
+from scipy.sparse import diags_array, sparray
 from scipy.sparse.linalg import bicgstab
 from sksparse.cholmod import cholesky
 from tqdm import tqdm
@@ -27,46 +27,44 @@ class EnIF:
 
     Parameters
     ----------
-    Prec_u : spmatrix, optional
+    Prec_u : sparray, optional
         Prior precision matrix of the state, shape (params, params). If omitted,
         it is estimated from data using `Graph_u` as the sparsity pattern.
     Graph_u : nx.Graph, optional
         Conditional-independence graph on the `params` state components,
         defining the sparsity of `Prec_u`. Required when `Prec_u` is not
         provided.
-    Prec_eps : spmatrix
+    Prec_eps : sparray
         Precision matrix of the observation noise, shape (responses, responses).
-    H : spmatrix, optional
+    H : sparray, optional
         Linear observation operator mapping state to responses, shape
         (responses, params). If omitted, it is estimated from data by `fit`.
     """
 
+    @staticmethod
+    def _validate_sparse_2d(name: str, value: sparray, square: bool = False) -> None:
+        if not (isinstance(value, sp.sparse.sparray) and value.ndim == 2):
+            raise TypeError(f"`{name}` must be a 2D sparse array")
+        if square and value.shape[0] != value.shape[1]:
+            raise ValueError(f"`{name}` must be a square 2D sparse array")
+
     def __init__(
         self,
         *,
-        Prec_u: spmatrix | None = None,
+        Prec_u: sparray | None = None,
         Graph_u: nx.Graph | None = None,
-        Prec_eps: spmatrix | None,
-        H: spmatrix | None = None,
+        Prec_eps: sparray,
+        H: sparray | None = None,
     ) -> None:
         assert Prec_u is not None or Graph_u is not None, (
             "Provide either Prec_u or Graph_u"
         )
 
-        if Prec_u is not None and not (
-            isinstance(Prec_u, sp.sparse.sparray) and Prec_u.ndim == 2
-        ):
-            raise TypeError("`Prec_u` must be a 2D sparse array")
-        if Prec_u is not None and Prec_u.shape[0] != Prec_u.shape[1]:
-            raise ValueError("`Prec_u` must be a square 2D sparse array")
-
-        if H is not None and not (isinstance(H, sp.sparse.sparray) and H.ndim == 2):
-            raise TypeError("`H` must be a 2D sparse array")
-
-        if Prec_eps is not None and not (
-            isinstance(Prec_eps, sp.sparse.sparray) and Prec_eps.ndim == 2
-        ):
-            raise TypeError("`Prec_eps` must be a 2D sparse array")
+        if Prec_u is not None:
+            self._validate_sparse_2d("Prec_u", Prec_u, square=True)
+        if H is not None:
+            self._validate_sparse_2d("H", H)
+        self._validate_sparse_2d("Prec_eps", Prec_eps, square=True)
 
         self.Prec_u = Prec_u
         self.Graph_u = Graph_u
@@ -77,8 +75,8 @@ class EnIF:
         # Convenience for re-use of cholesky and ordering
         self.Graph_C: nx.Graph | None = None
         self.perm_compose: NDArray[np.integer] | None = None
-        self.P_rev: spmatrix | None = None
-        self.P_order: spmatrix | None = None
+        self.P_rev: sparray | None = None
+        self.P_order: sparray | None = None
 
     def fit(
         self,
@@ -223,6 +221,7 @@ class EnIF:
             verbose_level=verbose_level - 1,
             ordering_method=ordering_method,
         )
+        self._validate_sparse_2d("Prec_u", self.Prec_u, square=True)
 
     def fit_H(
         self,
@@ -246,6 +245,7 @@ class EnIF:
             self.H = lr.linear_boost_ic_regression(
                 U, Y, verbose_level=verbose_level - 1
             )
+        self._validate_sparse_2d("H", self.H)
 
         self.unexplained_variance = lr.residual_variance(
             U, Y, self.H, verbose_level=verbose_level - 1
@@ -265,15 +265,13 @@ class EnIF:
         assert Eta.shape == U.shape, "Eta preserves the shape of U"
         return Eta
 
-    def Prec_residual_noisy(self, verbose_level: int = 0) -> spmatrix:
-        if self.Prec_eps is None:
-            raise ValueError("Prec_eps is not set.")
-        elif self.unexplained_variance is None:
+    def Prec_residual_noisy(self, verbose_level: int = 0) -> sparray:
+        if self.unexplained_variance is None:
             raise ValueError("`unexplained_variance` is not set.")
 
         eps_variances = 1.0 / self.Prec_eps.diagonal()
         residual_noisy_var = self.unexplained_variance + eps_variances
-        Prec_r = diags(1.0 / residual_noisy_var, 0, format="csc")
+        Prec_r = diags_array(1.0 / residual_noisy_var, offsets=0, format="csc")
         assert Prec_r.shape == self.Prec_eps.shape, (
             "Residuals and noise precision should have same shape"
         )

--- a/graphite_maps/linear_regression.py
+++ b/graphite_maps/linear_regression.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 from joblib import Parallel, delayed
 from numpy.typing import NDArray
 from scipy.integrate import quad
-from scipy.sparse import spmatrix
+from scipy.sparse import sparray
 from scipy.stats import chi2
 from sklearn.linear_model import LassoCV
 from sklearn.preprocessing import StandardScaler
@@ -12,7 +12,7 @@ from tqdm import tqdm
 
 def linear_l1_regression(
     U: NDArray[np.floating], Y: NDArray[np.floating], verbose_level: int = 0
-) -> sp.csc_matrix:
+) -> sp.csc_array:
     """Performs LASSO regression for each response in Y against predictors in
     U, constructing a sparse matrix of regression coefficients.
 
@@ -30,7 +30,7 @@ def linear_l1_regression(
 
     Returns
     -------
-    H_sparse : scipy.sparse.csc_matrix
+    H_sparse : scipy.sparse.csc_array
         Sparse matrix (m, p) with re-scaled LASSO regression coefficients for
         each response in Y.
     """
@@ -71,7 +71,7 @@ def linear_l1_regression(
                 / scaler_u.scale_[non_zero_ind]
             )
 
-    H_sparse = sp.csc_matrix(
+    H_sparse = sp.csc_array(
         (np.array(values_H), (np.array(i_H), np.array(j_H))), shape=(m, p)
     )
 
@@ -229,7 +229,7 @@ def linear_boost_ic_regression(
     effective_dimension: int | None = None,
     verbose_level: int = 0,
     n_jobs: int = -1,
-) -> sp.csc_matrix:
+) -> sp.csc_array:
     """Performs boosted linear regression for each response in Y against
     predictors in U, constructing a sparse matrix of regression coefficients.
     The complexity is tuned with an information theoretic approach.
@@ -250,7 +250,7 @@ def linear_boost_ic_regression(
 
     Returns
     -------
-    H_sparse : scipy.sparse.csc_matrix
+    H_sparse : scipy.sparse.csc_array
         Sparse matrix (m, p) with re-scaled LASSO regression coefficients for
         each response in Y.
     """
@@ -288,7 +288,7 @@ def linear_boost_ic_regression(
             scaler_y.scale_[j] * nonzero_values / scaler_u.scale_[nonzero_indices]
         )
 
-    H_sparse = sp.csc_matrix(
+    H_sparse = sp.csc_array(
         (np.concatenate(values_H), (np.concatenate(i_H), np.concatenate(j_H))),
         shape=(m, p),
     )
@@ -309,7 +309,7 @@ def linear_boost_ic_regression(
 def response_residual(
     U: NDArray[np.floating],
     Y: NDArray[np.floating],
-    H: spmatrix,
+    H: sparray,
     verbose_level: int = 0,
 ) -> NDArray[np.floating]:
     """Residual from regression H for Y on U"""
@@ -327,7 +327,7 @@ def response_residual(
 def residual_variance(
     U: NDArray[np.floating],
     Y: NDArray[np.floating],
-    H: spmatrix,
+    H: sparray,
     verbose_level: int = 0,
 ) -> NDArray[np.floating]:
     """Variance in Y not explained by U through H"""

--- a/graphite_maps/precision_estimation.py
+++ b/graphite_maps/precision_estimation.py
@@ -5,14 +5,14 @@ import numpy as np
 import scipy.sparse as sp
 from numpy.typing import NDArray
 from scipy.optimize import minimize
-from scipy.sparse import csc_matrix, tril
+from scipy.sparse import csc_array, tril
 from sksparse.cholmod import Factor, cholesky
 from tqdm import tqdm
 
 
 def find_sparsity_structure_from_chol(
     chol_LLT: Factor,
-) -> tuple[nx.Graph, NDArray[np.integer], csc_matrix, csc_matrix]:
+) -> tuple[nx.Graph, NDArray[np.integer], csc_array, csc_array]:
     L = chol_LLT.L()
     p = L.shape[0]
 
@@ -20,7 +20,7 @@ def find_sparsity_structure_from_chol(
     perm_order = chol_LLT.P()
 
     # Create the permutation matrix P
-    P_order = sp.csc_matrix(
+    P_order = sp.csc_array(
         (np.ones(len(perm_order)), (perm_order, np.arange(len(perm_order)))),
         shape=(p, p),
     )
@@ -28,7 +28,7 @@ def find_sparsity_structure_from_chol(
     # Create the reverse order permutation array
     perm_reverse = np.arange(p - 1, -1, -1)
     # Create the reverse permutation matrix
-    P_rev = sp.csc_matrix((np.ones(p), (perm_reverse, np.arange(p))), shape=(p, p))
+    P_rev = sp.csc_array((np.ones(p), (perm_reverse, np.arange(p))), shape=(p, p))
 
     # Apply in-fill reducing ordering permutation to reverse permutation
     perm_compose = perm_order[perm_reverse]
@@ -51,7 +51,7 @@ def find_sparsity_structure_from_graph(
     Graph_u: nx.Graph,
     ordering_method: str = "metis",
     verbose_level: int = 0,
-) -> tuple[nx.Graph, NDArray[np.integer], csc_matrix, csc_matrix]:
+) -> tuple[nx.Graph, NDArray[np.integer], csc_array, csc_array]:
     """
     Finds sparsity structure for lower triangular C so that
       C.T @ C = L @ L.T = P.T @ A @ P.
@@ -71,9 +71,9 @@ def find_sparsity_structure_from_graph(
         The graph representing the non-zero structure in C.
     perm_compose : NDArray[np.integer]
         The composed permutation array.
-    P_rev : scipy.sparse.csc_matrix
+    P_rev : scipy.sparse.csc_array
         The reverse permutation matrix.
-    P_order : scipy.sparse.csc_matrix
+    P_order : scipy.sparse.csc_array
         The in-fill reducing ordering permutation matrix.
 
     Examples
@@ -93,15 +93,15 @@ def find_sparsity_structure_from_graph(
     >>> perm_compose
     array([3, 2, 1, 0])
     >>> P_rev.todense()
-    matrix([[0., 0., 0., 1.],
-            [0., 0., 1., 0.],
-            [0., 1., 0., 0.],
-            [1., 0., 0., 0.]])
+    array([[0., 0., 0., 1.],
+           [0., 0., 1., 0.],
+           [0., 1., 0., 0.],
+           [1., 0., 0., 0.]])
     >>> P_order.todense()
-    matrix([[1., 0., 0., 0.],
-            [0., 1., 0., 0.],
-            [0., 0., 1., 0.],
-            [0., 0., 0., 1.]])
+    array([[1., 0., 0., 0.],
+           [0., 1., 0., 0.],
+           [0., 0., 1., 0.],
+           [0., 0., 0., 1.]])
     """
 
     # Create SPD matrix with same sparsity structure as Prec
@@ -239,7 +239,7 @@ def optimize_sparse_affine_kr_map(
     optimization_method: str = "L-BFGS-B",
     verbose_level: int = 0,
     use_tqdm: bool = True,
-) -> csc_matrix:
+) -> csc_array:
     """Optimize the affine Knothe-Rosenblatt (KR) map with standard Gaussian
     reference and l2-regularized dependence.
 
@@ -252,7 +252,7 @@ def optimize_sparse_affine_kr_map(
 
     Returns
     -------
-    scipy.sparse.csc_matrix
+    scipy.sparse.csc_array
         The optimized sparse Cholesky factor of the precision matrix.
     """
 
@@ -262,7 +262,7 @@ def optimize_sparse_affine_kr_map(
     _, p = U.shape
 
     # Initialize a sparse matrix for C_full
-    C_full = sp.lil_matrix((p, p))  # lil_matrix for efficient row operations
+    C_full = sp.lil_array((p, p))  # lil_array for efficient row operations
 
     loop_function = (
         tqdm(range(p), desc="Learning precision Cholesky factor row-by-row")
@@ -296,7 +296,7 @@ def optimize_sparse_affine_kr_map(
         C_full[k, non_zero_indices] = res.x
         C_full[k, k] = np.exp(C_full[k, k])  # res.x learns log diag
 
-    # Convert to csc_matrix for efficient storage and arithmetic operations
+    # Convert to csc_array for efficient storage and arithmetic operations
     return C_full.tocsc()
 
 
@@ -308,9 +308,9 @@ def fit_precision_cholesky(
     use_tqdm: bool = True,
     Graph_C: nx.Graph | None = None,
     perm_compose: NDArray[np.integer] | None = None,
-    P_rev: csc_matrix | None = None,
-    P_order: csc_matrix | None = None,
-) -> tuple[csc_matrix, nx.Graph, NDArray[np.integer], csc_matrix, csc_matrix]:
+    P_rev: csc_array | None = None,
+    P_order: csc_array | None = None,
+) -> tuple[csc_array, nx.Graph, NDArray[np.integer], csc_array, csc_array]:
     """
     Estimate the precision matrix using Cholesky decomposition.
     An l2-regularized negative log-likelihood is minimized.
@@ -323,7 +323,7 @@ def fit_precision_cholesky(
 
     Returns
     -------
-    scipy.sparse.csc_matrix
+    scipy.sparse.csc_array
         Estimated precision matrix.
     """
     _, p = U.shape
@@ -364,7 +364,7 @@ def fit_precision_cholesky_approximate(
     optimization_method: str = "L-BFGS-B",
     verbose_level: int = 0,
     use_tqdm: bool = True,
-) -> csc_matrix:
+) -> csc_array:
     """
     Estimate the precision matrix using approximate Cholesky.
     The Cholesky is assumed as sparse as the corresponding precision, with
@@ -387,7 +387,7 @@ def fit_precision_cholesky_approximate(
 
     Returns
     -------
-    scipy.sparse.csc_matrix
+    scipy.sparse.csc_array
         The optimized sparse Cholesky factor of the precision matrix.
     """
 

--- a/graphite_maps/utils.py
+++ b/graphite_maps/utils.py
@@ -1,10 +1,10 @@
 import numpy as np
 from numpy.typing import NDArray
-from scipy.sparse import spmatrix
+from scipy.sparse import sparray
 
 
 def generate_gaussian_noise(
-    n: int, Prec: spmatrix, seed: int | None = None, verbose_level: int = 0
+    n: int, Prec: sparray, seed: int | None = None, verbose_level: int = 0
 ) -> NDArray[np.floating]:
     """
     Generates 'n' samples of Gaussian noise with precision 'Prec'.
@@ -13,7 +13,7 @@ def generate_gaussian_noise(
     ----------
     n : int
         The number of samples to generate.
-    Prec : scipy.sparse.spmatrix
+    Prec : scipy.sparse.sparray
         The precision matrix for the Gaussian noise, assumed to be sparse.
 
     Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "matplotlib",
     "networkx",
     "scikit-learn",
-    "scipy",
+    "scipy>=1.11",
     "tqdm",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ dev = [
     "mypy",
     "pre-commit",
     "pytest",
-    "scikit-sparse; 'el8' not in platform_release", # Must be installed with linking towards libsuitesparse
-    "scikit-sparse < 0.5.0; 'el8' in platform_release",
+    "scikit-sparse < 0.5.0", # Must be installed with linking towards libsuitesparse
     "types-networkx",
     "types-tqdm",
 ]

--- a/tests/test_enif.py
+++ b/tests/test_enif.py
@@ -190,3 +190,40 @@ def test_that_iterative_pullback_matches_cholesky():
         canonical_posterior, update_indices=update_indices, U_prior=U, iterative=True
     )
     assert np.allclose(U_chol_partial, U_iter_partial, atol=1e-3)
+
+
+@pytest.mark.parametrize("algo", ["LASSO", "influence-boost"])
+def test_that_fit_attributes_round_trip_through_reconstruction(algo):
+    n, p, m, phi = 50, 80, 4, 0.5
+    U = nrar1(n, p, phi)
+
+    rng = np.random.default_rng(0)
+    H_true = np.zeros((m, p))
+    for j in range(m):
+        H_true[j, rng.integers(0, p)] = 1.0
+    Y = U @ H_true.T
+
+    Prec_eps = sp.sparse.csc_array(np.eye(m))
+    Graph_u = nx.path_graph(p)
+
+    trainer = EnIF(Graph_u=Graph_u, Prec_eps=Prec_eps)
+    trainer.fit(U, Y=Y, learning_algorithm=algo)
+    assert trainer.H.nnz > 0, f"fit({algo}) produced an all-zero H"
+
+    fresh = EnIF(
+        Prec_u=trainer.Prec_u.copy(),
+        Prec_eps=trainer.Prec_eps.copy(),
+        H=trainer.H.copy(),
+    )
+    fresh.unexplained_variance = trainer.unexplained_variance.copy()
+
+    d = np.zeros(m)
+    trainer_post = trainer.transport(U, Y, d, seed=42)
+    fresh_post = fresh.transport(U, Y, d, seed=42)
+
+    assert np.allclose(fresh_post, trainer_post, atol=1e-12), (
+        "Reconstructed EnIF produced a different posterior than the trainer"
+    )
+    assert not np.allclose(trainer_post, U), (
+        "transport() returned the prior unchanged, H had no effect"
+    )


### PR DESCRIPTION
The current workflow of enif as used by ERT does not work since it is not consistent with the usage of sparse arrays vs sparse matrix. This converts everything to sparse arrays.
Might break stuff for "users", but I think that should be fine, and also easy to fix.