### PR TITLE
Remove print in favor of logging

### DIFF
--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -341,8 +341,8 @@ class EnIF:
             return 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
 
         # Only print this if logging is on. Cholesky can be heavy
-        logdet = OnDemand(logdet)
-        log.info("Prior precision log-determinant: %.3f", logdet)
+        logdet_ondemand = OnDemand(logdet)
+        log.info("Prior precision log-determinant: %.3f", logdet_ondemand)
 
         updated_canonical = canonical.copy()
         Prec_r = self.Prec_residual_noisy()

--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -254,9 +254,7 @@ class EnIF:
             self.H,
         )
 
-    def pushforward_to_canonical(
-        self, U: NDArray[np.floating], verbose_level: int = 0
-    ) -> NDArray[np.floating]:
+    def pushforward_to_canonical(self, U: NDArray[np.floating]) -> NDArray[np.floating]:
         """
         Map each realization u in U to canonical space eta = Prec * u
         """
@@ -267,7 +265,7 @@ class EnIF:
         assert Eta.shape == U.shape, "Eta preserves the shape of U"
         return Eta
 
-    def Prec_residual_noisy(self, verbose_level: int = 0) -> sparray:
+    def Prec_residual_noisy(self) -> sparray:
         if self.unexplained_variance is None:
             raise ValueError("`unexplained_variance` is not set.")
 
@@ -368,7 +366,6 @@ class EnIF:
         update_indices: NDArray[np.integer] | None = None,
         U_prior: NDArray[np.floating] | None = None,
         iterative: bool = False,
-        verbose_level: int = 0,
     ) -> NDArray[np.floating]:
         """
         Solve u = Prec * eta using selective updates for specified indices,

--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -278,9 +278,9 @@ class EnIF:
             "Residuals and noise precision should have same shape"
         )
 
-        log.info(f"Total residual variance: {np.sum(residual_noisy_var):.4f}")
-        log.info(f"Unexplained variance: {np.sum(self.unexplained_variance):.4f}")
-        log.info(f"Measurement variance: {np.sum(eps_variances):.4f}")
+        log.info("Total residual variance: %.4f", np.sum(residual_noisy_var))
+        log.info("Unexplained variance: %.4f", np.sum(self.unexplained_variance))
+        log.info("Measurement variance: %.4f", np.sum(eps_variances))
         return Prec_r
 
     def response_residual(
@@ -335,7 +335,7 @@ class EnIF:
         assert n == n_r, "canonical and residual_noisy must have equal samples"
         assert d.shape == (m,), "d and residual_noisy must have matching dimension"
 
-        def logdet():
+        def logdet() -> float:
             # Compute the current log-determinant
             chol_LLT = cholesky(self.Prec_u, ordering_method="metis")
             return 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
@@ -472,7 +472,7 @@ class EnIF:
             current_nodes = new_nodes.copy()
 
         param_num, tot_num = len(all_nodes), adjacency.shape[0]
-        log.info(f"Retrieving {param_num} parameters out of {tot_num}")
+        log.info("Retrieving %d parameters out of %d", param_num, tot_num)
 
         return np.array(list(all_nodes), dtype=int)
 

--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -335,12 +335,10 @@ class EnIF:
         assert n == n_r, "canonical and residual_noisy must have equal samples"
         assert d.shape == (m,), "d and residual_noisy must have matching dimension"
 
-        # Compute the current log-determinant
-        chol_LLT = cholesky(self.Prec_u, ordering_method="metis")
-        logdet_value = 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
-
         # Only print this if logging is on. Cholesky can be heavy
         if log.isEnabledFor(logging.INFO):
+            chol_LLT = cholesky(self.Prec_u, ordering_method="metis")
+            logdet_value = 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
             log.info("Prior precision log-determinant: %.3f", logdet_value)
 
         updated_canonical = canonical.copy()

--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -15,7 +15,7 @@ from graphite_maps.precision_estimation import (
     find_sparsity_structure_from_chol,
     fit_precision_cholesky,
 )
-from graphite_maps.utils import OnDemand, generate_gaussian_noise
+from graphite_maps.utils import generate_gaussian_noise
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -335,14 +335,13 @@ class EnIF:
         assert n == n_r, "canonical and residual_noisy must have equal samples"
         assert d.shape == (m,), "d and residual_noisy must have matching dimension"
 
-        def logdet() -> float:
-            # Compute the current log-determinant
-            chol_LLT = cholesky(self.Prec_u, ordering_method="metis")
-            return 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
+        # Compute the current log-determinant
+        chol_LLT = cholesky(self.Prec_u, ordering_method="metis")
+        logdet_value = 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
 
         # Only print this if logging is on. Cholesky can be heavy
-        logdet_ondemand = OnDemand(logdet)
-        log.info("Prior precision log-determinant: %.3f", logdet_ondemand)
+        if log.isEnabledFor(logging.INFO):
+            log.info("Prior precision log-determinant: %.3f", logdet_value)
 
         updated_canonical = canonical.copy()
         Prec_r = self.Prec_residual_noisy()

--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Literal
 
 import networkx as nx
@@ -14,7 +15,10 @@ from graphite_maps.precision_estimation import (
     find_sparsity_structure_from_chol,
     fit_precision_cholesky,
 )
-from graphite_maps.utils import generate_gaussian_noise
+from graphite_maps.utils import OnDemand, generate_gaussian_noise
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class EnIF:
@@ -84,7 +88,6 @@ class EnIF:
         Y: NDArray[np.floating] | None = None,
         learning_algorithm: Literal["LASSO", "influence-boost"] = "LASSO",
         ordering_method: str = "metis",
-        verbose_level: int = 0,
     ) -> None:
         """Fit the prior precision of `u` and, optionally the mapping `H`.
 
@@ -106,27 +109,24 @@ class EnIF:
         ordering_method : str, default="metis"
             Fill-reducing ordering passed to the Cholesky factorization when
             estimating `Prec_u`.
-        verbose_level : int, default=0
         """
 
         if self.Prec_u is None:
             self.fit_precision(
                 U,
-                verbose_level=verbose_level - 1,
                 ordering_method=ordering_method,
             )
-        elif verbose_level > 0:
-            print("Precision u exists. Use `fit_precision` to refit if necessary")
+        else:
+            log.info("Precision u exists. Use `fit_precision` to refit if necessary")
         if Y is not None:
             assert self.H is None, "Y should not be provided if H exists"
             self.fit_H(
                 U=U,
                 Y=Y,
                 learning_algorithm=learning_algorithm,
-                verbose_level=verbose_level - 1,
             )
-        elif verbose_level > 0:
-            print("H mapping exists. Use `fit_H` to refit if necessary")
+        else:
+            log.info("H mapping exists. Use `fit_H` to refit if necessary")
 
     def transport(
         self,
@@ -136,7 +136,6 @@ class EnIF:
         update_indices: NDArray[np.integer] | None = None,
         seed: int | None = None,
         iterative: bool = False,
-        verbose_level: int = 0,
     ) -> NDArray[np.floating]:
         """Transport a prior ensemble to the posterior given observations `d`.
 
@@ -160,7 +159,6 @@ class EnIF:
             components.
         seed : int, optional
         iterative : bool, default=False
-        verbose_level : int, default=0
 
         Returns
         -------
@@ -174,19 +172,22 @@ class EnIF:
         assert d.shape == (m,), "Observations must match responses"
 
         # Map parameters to canonical parametrization
-        canonical = self.pushforward_to_canonical(U, verbose_level=verbose_level - 1)
+        canonical = self.pushforward_to_canonical(U)
 
         # Work out residuals and associate unexplained variance
-        residuals = self.response_residual(U, Y, verbose_level=verbose_level - 1)
+        residuals = self.response_residual(U, Y)
         # Due to observation error
         eps = self.generate_observation_noise(
-            n, seed=seed, verbose_level=verbose_level - 1
+            n,
+            seed=seed,
         )
         residual_noisy = residuals + eps
 
         # Update in canonical parametrization
         canonical_updated = self.update_canonical(
-            canonical, residual_noisy, d, verbose_level=verbose_level - 1
+            canonical,
+            residual_noisy,
+            d,
         )
 
         # Bring realizations back
@@ -195,7 +196,6 @@ class EnIF:
             update_indices=update_indices,
             U_prior=U,
             iterative=iterative,
-            verbose_level=verbose_level - 1,
         )
 
     # Low-level API methods
@@ -203,7 +203,6 @@ class EnIF:
         self,
         U: NDArray[np.floating],
         ordering_method: str = "metis",
-        verbose_level: int = 0,
     ) -> None:
         """
         Estimate self.Prec_u from data U w.r.t. graph self.Graph_u
@@ -218,7 +217,6 @@ class EnIF:
         ) = fit_precision_cholesky(
             U=U,
             Graph_u=self.Graph_u,
-            verbose_level=verbose_level - 1,
             ordering_method=ordering_method,
         )
         self._validate_sparse_2d("Prec_u", self.Prec_u, square=True)
@@ -228,7 +226,6 @@ class EnIF:
         U: NDArray[np.floating],
         Y: NDArray[np.floating],
         learning_algorithm: Literal["LASSO", "influence-boost"] = "LASSO",
-        verbose_level: int = 0,
     ) -> None:
         """
         Estimate H from data U using (sparse) linear regression
@@ -240,15 +237,21 @@ class EnIF:
             )
 
         if learning_algorithm == "LASSO":
-            self.H = lr.linear_l1_regression(U, Y, verbose_level=verbose_level - 1)
+            self.H = lr.linear_l1_regression(
+                U,
+                Y,
+            )
         else:
             self.H = lr.linear_boost_ic_regression(
-                U, Y, verbose_level=verbose_level - 1
+                U,
+                Y,
             )
         self._validate_sparse_2d("H", self.H)
 
         self.unexplained_variance = lr.residual_variance(
-            U, Y, self.H, verbose_level=verbose_level - 1
+            U,
+            Y,
+            self.H,
         )
 
     def pushforward_to_canonical(
@@ -257,8 +260,7 @@ class EnIF:
         """
         Map each realization u in U to canonical space eta = Prec * u
         """
-        if verbose_level > 0:
-            print("Mapping realizations to canonical space")
+        log.info("Mapping realizations to canonical space")
 
         assert self.Prec_u is not None, "Precision must exist to pushforward"
         Eta = U @ self.Prec_u
@@ -275,34 +277,44 @@ class EnIF:
         assert Prec_r.shape == self.Prec_eps.shape, (
             "Residuals and noise precision should have same shape"
         )
-        if verbose_level > 0:
-            print(
-                f"Total residual variance: {np.sum(residual_noisy_var)}\n"
-                f"Unexplained variance: {np.sum(self.unexplained_variance)}\n"
-                f"Measurement variance: {np.sum(eps_variances)}"
-            )
+
+        log.info(f"Total residual variance: {np.sum(residual_noisy_var):.4f}")
+        log.info(f"Unexplained variance: {np.sum(self.unexplained_variance):.4f}")
+        log.info(f"Measurement variance: {np.sum(eps_variances):.4f}")
         return Prec_r
 
     def response_residual(
-        self, U: NDArray[np.floating], Y: NDArray[np.floating], verbose_level: int = 0
+        self,
+        U: NDArray[np.floating],
+        Y: NDArray[np.floating],
     ) -> NDArray[np.floating]:
         """Residual from regression self.H for Y on U"""
         if self.H is None:
             raise ValueError("H is not set.")
 
         self.unexplained_variance = lr.residual_variance(
-            U, Y, self.H, verbose_level=verbose_level - 1
+            U,
+            Y,
+            self.H,
         )
 
-        return lr.response_residual(U, Y, self.H, verbose_level=verbose_level - 1)
+        return lr.response_residual(
+            U,
+            Y,
+            self.H,
+        )
 
     def generate_observation_noise(
-        self, n: int, seed: int | None = None, verbose_level: int = 0
+        self,
+        n: int,
+        seed: int | None = None,
     ) -> NDArray[np.floating]:
         """Sample n realizations of observation noise."""
 
         return generate_gaussian_noise(
-            n, self.Prec_eps, seed=seed, verbose_level=verbose_level - 1
+            n,
+            self.Prec_eps,
+            seed=seed,
         )
 
     def update_canonical(
@@ -310,7 +322,6 @@ class EnIF:
         canonical: NDArray[np.floating],
         residual_noisy: NDArray[np.floating],
         d: NDArray[np.floating],
-        verbose_level: int = 0,
     ) -> NDArray[np.floating]:
         """
         Use information-filter equations to update (eta, Prec) using perturbed
@@ -324,13 +335,17 @@ class EnIF:
         assert n == n_r, "canonical and residual_noisy must have equal samples"
         assert d.shape == (m,), "d and residual_noisy must have matching dimension"
 
-        if verbose_level > 5:
+        def logdet():
+            # Compute the current log-determinant
             chol_LLT = cholesky(self.Prec_u, ordering_method="metis")
-            prior_logdet = 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
-            print(f"Prior precision log-determinant: {prior_logdet}")
+            return 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
+
+        # Only print this if logging is on. Cholesky can be heavy
+        logdet = OnDemand(logdet)
+        log.info("Prior precision log-determinant: %.3f", logdet)
 
         updated_canonical = canonical.copy()
-        Prec_r = self.Prec_residual_noisy(verbose_level=verbose_level - 1)
+        Prec_r = self.Prec_residual_noisy()
         for i in range(n):
             d_adjusted = d - residual_noisy[i, :]
             # Eqn (46) from the paper
@@ -339,16 +354,14 @@ class EnIF:
         # posterior precision
         self.Prec_u = self.Prec_u + self.H.T @ Prec_r @ self.H  # Eqn (47)
 
-        # Only print this if one really wants it. The cholesky can be heavy
-        if verbose_level > 5:
-            chol_LLT = cholesky(self.Prec_u, ordering_method="metis")
-            posterior_logdet = 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
-            print(f"Posterior precision log-determinant: {posterior_logdet}")
+        chol_LLT = cholesky(self.Prec_u, ordering_method="metis")
+        logdet_value = 2.0 * np.sum(np.log(chol_LLT.L().diagonal()))
+        log.info("Posterior precision log-determinant: %.3f", logdet_value)
 
-            # Update the ordering knowledge
-            self.Graph_C, self.perm_compose, self.P_rev, self.P_order = (
-                find_sparsity_structure_from_chol(chol_LLT=chol_LLT)
-            )
+        # Update the ordering knowledge
+        self.Graph_C, self.perm_compose, self.P_rev, self.P_order = (
+            find_sparsity_structure_from_chol(chol_LLT=chol_LLT)
+        )
 
         return updated_canonical
 
@@ -367,8 +380,7 @@ class EnIF:
         """
         assert self.Prec_u is not None, "Prec_u must exist"
 
-        if verbose_level > 0:
-            print("Mapping canonical-scaled realizations to moment realization")
+        log.info("Mapping canonical-scaled realizations to moment realization")
 
         p = updated_canonical.shape[1]  # Number of columns in the matrix
         all_indices = np.arange(p, dtype=int)
@@ -424,7 +436,6 @@ class EnIF:
     def get_update_indices(
         self,
         neighbor_propagation_order: int = 10,
-        verbose_level: int = 0,
     ) -> NDArray[np.integer]:
         """
         Determine indices to update based on the order of neighbor propagation.
@@ -460,11 +471,8 @@ class EnIF:
             all_nodes.update(new_nodes)
             current_nodes = new_nodes.copy()
 
-        if verbose_level > 0:
-            print(
-                f"Retrieving {len(all_nodes)} parameters out of a total "
-                f"{adjacency.shape[0]}"
-            )
+        param_num, tot_num = len(all_nodes), adjacency.shape[0]
+        log.info(f"Retrieving {param_num} parameters out of {tot_num}")
 
         return np.array(list(all_nodes), dtype=int)
 

--- a/graphite_maps/linear_regression.py
+++ b/graphite_maps/linear_regression.py
@@ -46,7 +46,7 @@ def linear_l1_regression(
     if n != n_y:
         raise ValueError("Number of samples in U and Y must be the same")
 
-    log.info(f"Learning sparse linear map of shape {(m, p)}")
+    log.info("Learning sparse linear map of shape %s", (m, p))
 
     scaler_u = StandardScaler()
     U_scaled = scaler_u.fit_transform(U)
@@ -81,7 +81,9 @@ def linear_l1_regression(
 
     assert H_sparse.shape == (m, p), "Shape of H_sparse must be (m, p)"
 
-    log.info(f"Density: {H_sparse.nnz / (m * p):.1%} ({H_sparse.nnz} / {m * p})")
+    log.info(
+        "Density: %.1f%% (%d / %d)", 100 * H_sparse.nnz / (m * p), H_sparse.nnz, m * p
+    )
 
     return H_sparse
 
@@ -259,7 +261,7 @@ def linear_boost_ic_regression(
     if n != n_y:
         raise ValueError("Number of samples in U and Y must be the same")
 
-    log.info(f"Learning sparse linear map of shape {(m, p)}")
+    log.info("Learning sparse linear map of shape %s", (m, p))
 
     scaler_u = StandardScaler()
     U_scaled = scaler_u.fit_transform(U)
@@ -293,7 +295,9 @@ def linear_boost_ic_regression(
     # Assert shape of H_sparse
     assert H_sparse.shape == (m, p), "Shape of H_sparse must be (m, p)"
 
-    log.info(f"Density: {H_sparse.nnz / (m * p):.1%} ({H_sparse.nnz} / {m * p})")
+    log.info(
+        "Density: %.1f%% (%d / %d)", 100 * H_sparse.nnz / (m * p), H_sparse.nnz, m * p
+    )
 
     return H_sparse
 

--- a/graphite_maps/linear_regression.py
+++ b/graphite_maps/linear_regression.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 import scipy.sparse as sp
 from joblib import Parallel, delayed
@@ -9,9 +11,12 @@ from sklearn.linear_model import LassoCV
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
 
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
 
 def linear_l1_regression(
-    U: NDArray[np.floating], Y: NDArray[np.floating], verbose_level: int = 0
+    U: NDArray[np.floating], Y: NDArray[np.floating]
 ) -> sp.csc_array:
     """Performs LASSO regression for each response in Y against predictors in
     U, constructing a sparse matrix of regression coefficients.
@@ -41,8 +46,7 @@ def linear_l1_regression(
     if n != n_y:
         raise ValueError("Number of samples in U and Y must be the same")
 
-    if verbose_level > 0:
-        print(f"Learning sparse linear map of shape {(m, p)}")
+    log.info(f"Learning sparse linear map of shape {(m, p)}")
 
     scaler_u = StandardScaler()
     U_scaled = scaler_u.fit_transform(U)
@@ -77,12 +81,7 @@ def linear_l1_regression(
 
     assert H_sparse.shape == (m, p), "Shape of H_sparse must be (m, p)"
 
-    if verbose_level > 0:
-        print(
-            f"Total elements: {m * p}\n"
-            f"Non-zero elements: {H_sparse.nnz}\n"
-            f"Fraction of non-zeros: {H_sparse.nnz / (m * p)}"
-        )
+    log.info(f"Density: {H_sparse.nnz / (m * p):.1%} ({H_sparse.nnz} / {m * p})")
 
     return H_sparse
 
@@ -227,7 +226,6 @@ def linear_boost_ic_regression(
     Y: NDArray[np.floating],
     learning_rate: float = 0.5,
     effective_dimension: int | None = None,
-    verbose_level: int = 0,
     n_jobs: int = -1,
 ) -> sp.csc_array:
     """Performs boosted linear regression for each response in Y against
@@ -261,8 +259,7 @@ def linear_boost_ic_regression(
     if n != n_y:
         raise ValueError("Number of samples in U and Y must be the same")
 
-    if verbose_level > 0:
-        print(f"Learning sparse linear map of shape {(m, p)}")
+    log.info(f"Learning sparse linear map of shape {(m, p)}")
 
     scaler_u = StandardScaler()
     U_scaled = scaler_u.fit_transform(U)
@@ -296,12 +293,7 @@ def linear_boost_ic_regression(
     # Assert shape of H_sparse
     assert H_sparse.shape == (m, p), "Shape of H_sparse must be (m, p)"
 
-    if verbose_level > 0:
-        print(
-            f"Total elements: {m * p}\n"
-            f"Non-zero elements: {H_sparse.nnz}\n"
-            f"Fraction of non-zeros: {H_sparse.nnz / (m * p)}"
-        )
+    log.info(f"Density: {H_sparse.nnz / (m * p):.1%} ({H_sparse.nnz} / {m * p})")
 
     return H_sparse
 
@@ -310,7 +302,6 @@ def response_residual(
     U: NDArray[np.floating],
     Y: NDArray[np.floating],
     H: sparray,
-    verbose_level: int = 0,
 ) -> NDArray[np.floating]:
     """Residual from regression H for Y on U"""
     n_u, p = U.shape
@@ -318,8 +309,7 @@ def response_residual(
     assert n_u == n_y, "Number of ensembles must be the same"
     assert (m, p) == H.shape, "Coefficients in H must match U and Y dimensions"
 
-    if verbose_level > 0:
-        print("Calculating response residuals")
+    log.info("Calculating response residuals")
 
     return Y - U @ H.T
 
@@ -328,7 +318,6 @@ def residual_variance(
     U: NDArray[np.floating],
     Y: NDArray[np.floating],
     H: sparray,
-    verbose_level: int = 0,
 ) -> NDArray[np.floating]:
     """Variance in Y not explained by U through H"""
 
@@ -344,8 +333,7 @@ def residual_variance(
         "Number of variance components must match number of observations"
     )
 
-    if verbose_level > 0:
-        print("Calculating unexplained variance")
+    log.info("Calculating unexplained variance")
 
     return unexplained_variance
 

--- a/graphite_maps/precision_estimation.py
+++ b/graphite_maps/precision_estimation.py
@@ -115,21 +115,21 @@ def find_sparsity_structure_from_graph(
     # This ensures all eigenvalues are in a circle centered at max_degree+1.0
     # and radius < (max_degree+1.0), so guaranteed > 0
     max_degree = max(dict(Graph_u.degree()).values())
-    log.info(f"max degree of graph is: {max_degree}")
+    log.info("max degree of graph is: %s", max_degree)
     SPD_Prec.setdiag(max_degree + 1.0)
 
     # PT prec P = LLT
     start = time.perf_counter()
     chol_LLT = cholesky(SPD_Prec, ordering_method=ordering_method)
     end = time.perf_counter()
-    log.info(f"Permutation optimization took {end - start:.2f} seconds")
+    log.info("Permutation optimization took %.2f seconds", end - start)
 
     Graph_C, perm_compose, P_rev, P_order = find_sparsity_structure_from_chol(
         chol_LLT=chol_LLT
     )
 
-    log.info(f"Parameters in precision: {tril(SPD_Prec).nnz}\n")
-    log.info(f"Parameters in Cholesky factor: {Graph_C.number_of_edges()}")
+    log.info("Parameters in precision: %s\n", tril(SPD_Prec).nnz)
+    log.info("Parameters in Cholesky factor: %s", Graph_C.number_of_edges())
 
     # Return the results
     return Graph_C, perm_compose, P_rev, P_order
@@ -342,7 +342,7 @@ def fit_precision_cholesky(
     # 2.b Compute log-determinant of estimate, for logging
     L_r = P_rev @ C.T @ P_rev  # Factor of reverse precision
     prec_logdet = 2.0 * np.sum(np.log(L_r.diagonal()))
-    log.info(f"Precision has log-determinant: {prec_logdet:.3f}")
+    log.info("Precision has log-determinant: %.3f", prec_logdet)
 
     # 3. Unwrap C to yield precision (Eqn 73 in paper)
     Prec = P_order @ P_rev @ (C.T @ C) @ P_rev @ P_order.T

--- a/graphite_maps/precision_estimation.py
+++ b/graphite_maps/precision_estimation.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 import networkx as nx
@@ -8,6 +9,9 @@ from scipy.optimize import minimize
 from scipy.sparse import csc_array, tril
 from sksparse.cholmod import Factor, cholesky
 from tqdm import tqdm
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 def find_sparsity_structure_from_chol(
@@ -50,7 +54,6 @@ def find_sparsity_structure_from_chol(
 def find_sparsity_structure_from_graph(
     Graph_u: nx.Graph,
     ordering_method: str = "metis",
-    verbose_level: int = 0,
 ) -> tuple[nx.Graph, NDArray[np.integer], csc_array, csc_array]:
     """
     Finds sparsity structure for lower triangular C so that
@@ -112,26 +115,21 @@ def find_sparsity_structure_from_graph(
     # This ensures all eigenvalues are in a circle centered at max_degree+1.0
     # and radius < (max_degree+1.0), so guaranteed > 0
     max_degree = max(dict(Graph_u.degree()).values())
-    if verbose_level > 0:
-        print(f"max degree of graph is: {max_degree}")
+    log.info(f"max degree of graph is: {max_degree}")
     SPD_Prec.setdiag(max_degree + 1.0)
 
     # PT prec P = LLT
     start = time.perf_counter()
     chol_LLT = cholesky(SPD_Prec, ordering_method=ordering_method)
     end = time.perf_counter()
-    if verbose_level > 0:
-        print(f"Permutation optimization took {end - start:.2f} seconds")
+    log.info(f"Permutation optimization took {end - start:.2f} seconds")
 
     Graph_C, perm_compose, P_rev, P_order = find_sparsity_structure_from_chol(
         chol_LLT=chol_LLT
     )
 
-    if verbose_level > 0:
-        print(
-            f"Parameters in precision: {tril(SPD_Prec).nnz}\n"
-            f"Parameters in Cholesky factor: {Graph_C.number_of_edges()}"
-        )
+    log.info(f"Parameters in precision: {tril(SPD_Prec).nnz}\n")
+    log.info(f"Parameters in Cholesky factor: {Graph_C.number_of_edges()}")
 
     # Return the results
     return Graph_C, perm_compose, P_rev, P_order
@@ -237,7 +235,6 @@ def optimize_sparse_affine_kr_map(
     U: NDArray[np.floating],
     G: nx.Graph,
     optimization_method: str = "L-BFGS-B",
-    verbose_level: int = 0,
     use_tqdm: bool = True,
 ) -> csc_array:
     """Optimize the affine Knothe-Rosenblatt (KR) map with standard Gaussian
@@ -256,8 +253,7 @@ def optimize_sparse_affine_kr_map(
         The optimized sparse Cholesky factor of the precision matrix.
     """
 
-    if verbose_level > 0:
-        print("Starting statistical fitting of precision")
+    log.info("Starting statistical fitting of precision")
 
     _, p = U.shape
 
@@ -304,7 +300,6 @@ def fit_precision_cholesky(
     U: NDArray[np.floating],
     Graph_u: nx.Graph,
     ordering_method: str = "metis",
-    verbose_level: int = 0,
     use_tqdm: bool = True,
     Graph_C: nx.Graph | None = None,
     perm_compose: NDArray[np.integer] | None = None,
@@ -333,7 +328,6 @@ def fit_precision_cholesky(
         # 1. Find in-fill reducing ordering for C
         Graph_C, perm_compose, P_rev, P_order = find_sparsity_structure_from_graph(
             Graph_u,
-            verbose_level=verbose_level - 1,
             ordering_method=ordering_method,
         )
 
@@ -342,15 +336,13 @@ def fit_precision_cholesky(
     C = optimize_sparse_affine_kr_map(
         U=U_perm,
         G=Graph_C,
-        verbose_level=verbose_level - 1,
         use_tqdm=use_tqdm,
     )
 
     # 2.b Compute log-determinant of estimate, for logging
-    if verbose_level > 0:
-        L_r = P_rev @ C.T @ P_rev  # Factor of reverse precision
-        prec_logdet = 2.0 * np.sum(np.log(L_r.diagonal()))
-        print(f"Precision has log-determinant: {prec_logdet}")
+    L_r = P_rev @ C.T @ P_rev  # Factor of reverse precision
+    prec_logdet = 2.0 * np.sum(np.log(L_r.diagonal()))
+    log.info(f"Precision has log-determinant: {prec_logdet:.3f}")
 
     # 3. Unwrap C to yield precision (Eqn 73 in paper)
     Prec = P_order @ P_rev @ (C.T @ C) @ P_rev @ P_order.T
@@ -362,7 +354,6 @@ def fit_precision_cholesky_approximate(
     G: nx.Graph,
     neighbourhood_expansion: int = 2,
     optimization_method: str = "L-BFGS-B",
-    verbose_level: int = 0,
     use_tqdm: bool = True,
 ) -> csc_array:
     """
@@ -409,7 +400,6 @@ def fit_precision_cholesky_approximate(
         U=U,
         G=G_expanded,
         optimization_method=optimization_method,
-        verbose_level=verbose_level - 1,
         use_tqdm=use_tqdm,
     )
 

--- a/graphite_maps/utils.py
+++ b/graphite_maps/utils.py
@@ -1,10 +1,15 @@
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 from scipy.sparse import sparray
 
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
 
 def generate_gaussian_noise(
-    n: int, Prec: sparray, seed: int | None = None, verbose_level: int = 0
+    n: int, Prec: sparray, seed: int | None = None
 ) -> NDArray[np.floating]:
     """
     Generates 'n' samples of Gaussian noise with precision 'Prec'.
@@ -41,9 +46,7 @@ def generate_gaussian_noise(
 
     assert eps.shape == (n, m), "Sampling returns wrong size"
 
-    if verbose_level > 0:
-        print(
-            f"Sampling with seed={seed}\nSampled Gaussian noise with shape {eps.shape}"
-        )
+    log.info("Sampling with seed=%s", seed)
+    log.info("Sampled Gaussian noise with shape=%s", eps.shape)
 
     return eps

--- a/graphite_maps/utils.py
+++ b/graphite_maps/utils.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import Any
+
 import numpy as np
 from numpy.typing import NDArray
 from scipy.sparse import sparray
@@ -8,11 +11,11 @@ class OnDemand:
     https://orbifold.xyz/logging-expensive.html
     """
 
-    def __init__(self, callable) -> None:
-        self.callable = callable
+    def __init__(self, func: Callable[[], Any]) -> None:
+        self.func = func
 
     def __repr__(self) -> str:
-        return repr(self.callable())
+        return repr(self.func())
 
 
 def generate_gaussian_noise(

--- a/graphite_maps/utils.py
+++ b/graphite_maps/utils.py
@@ -1,21 +1,6 @@
-from collections.abc import Callable
-from typing import Any
-
 import numpy as np
 from numpy.typing import NDArray
 from scipy.sparse import sparray
-
-
-class OnDemand:
-    """Only call the function if needed, see:
-    https://orbifold.xyz/logging-expensive.html
-    """
-
-    def __init__(self, func: Callable[[], Any]) -> None:
-        self.func = func
-
-    def __repr__(self) -> str:
-        return repr(self.func())
 
 
 def generate_gaussian_noise(

--- a/graphite_maps/utils.py
+++ b/graphite_maps/utils.py
@@ -3,6 +3,18 @@ from numpy.typing import NDArray
 from scipy.sparse import sparray
 
 
+class OnDemand:
+    """Only call the function if needed, see:
+    https://orbifold.xyz/logging-expensive.html
+    """
+
+    def __init__(self, callable) -> None:
+        self.callable = callable
+
+    def __repr__(self) -> str:
+        return repr(self.callable())
+
+
 def generate_gaussian_noise(
     n: int, Prec: sparray, seed: int | None = None, verbose_level: int = 0
 ) -> NDArray[np.floating]:

--- a/tests/test_enif.py
+++ b/tests/test_enif.py
@@ -113,7 +113,6 @@ def test_snapshot_lowlevel():
     H = linear_boost_ic_regression(
         U=U,
         Y=Y,
-        verbose_level=5,
     )
 
     desired_H = np.array([0.0, 0.74667254, 1.21359438, 0.0, 0.0])
@@ -124,7 +123,6 @@ def test_snapshot_lowlevel():
         U=U,
         G=Graph_u,
         neighbourhood_expansion=2,
-        verbose_level=2,
         use_tqdm=True,
     )
 
@@ -141,7 +139,7 @@ def test_snapshot_lowlevel():
     )
 
     update_indices = gtmap.get_update_indices(
-        neighbor_propagation_order=15, verbose_level=1
+        neighbor_propagation_order=15,
     )
     X_updated = gtmap.transport(
         U=U,
@@ -149,7 +147,6 @@ def test_snapshot_lowlevel():
         d=d,
         update_indices=update_indices,
         iterative=False,
-        verbose_level=5,
         seed=13,
     )
 

--- a/tests/test_enif.py
+++ b/tests/test_enif.py
@@ -72,14 +72,16 @@ def test_snapshot():
 
     # Call the high-level API, using "Prec_u"
     Prec_u = rng.normal(size=(n_params, n_params))
-    Prec_u = Prec_u.T + Prec_u + np.eye(n_params)
-    assert np.abs(np.linalg.eig(Prec_u).eigenvalues.min()) > 0
+    Prec_u = Prec_u.T + Prec_u
+    shift = np.abs(np.linalg.eigvalsh(Prec_u).min()) + 1.0
+    Prec_u = Prec_u + shift * np.eye(n_params)
+    assert np.linalg.eigvalsh(Prec_u).min() > 0
 
     gtmap = EnIF(Prec_u=sp.sparse.csc_array(Prec_u), Prec_eps=Prec_eps, H=H)
     gtmap.fit(U, ordering_method="natural")
     U_posterior = gtmap.transport(U, Y, d, seed=42)
 
-    desired = np.array([0.05722, 0.521217, -0.972532, 0.621532, -1.440641])
+    desired = np.array([-0.042127, -0.421971, -0.94604, -0.261284, -1.491031])
     np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-5)
 
 

--- a/tests/test_enif.py
+++ b/tests/test_enif.py
@@ -1,3 +1,6 @@
+import logging
+import sys
+
 import networkx as nx
 import numpy as np
 import pytest
@@ -50,6 +53,11 @@ def create_ar1_precision(p, phi):
 def test_snapshot_highlevel():
     """This snapshot test is meant to altert us if behavoir changes.
     If this is intended, then simply update the values below."""
+
+    # Smoketest that logging works
+    log = logging.getLogger("graphite_maps")
+    log.setLevel(logging.DEBUG)
+    log.addHandler(logging.StreamHandler(stream=sys.stdout))
 
     # Size of the problem
     rng = np.random.default_rng(42)

--- a/tests/test_enif.py
+++ b/tests/test_enif.py
@@ -107,8 +107,8 @@ def test_that_posterior_low_level_api_equals_high_level_api(n, p, phi):
 
     # EnIF high-level API
     gtmap = EnIF(Graph_u=Graph_u, Prec_eps=Prec_eps, H=H)
-    gtmap.fit(U, verbose_level=4)
-    U_posterior_highlevel = gtmap.transport(U, Y, d, seed=42, verbose_level=10)
+    gtmap.fit(U)
+    U_posterior_highlevel = gtmap.transport(U, Y, d, seed=42)
 
     # EnIF low-level API
     gtmap_lowlevel = EnIF(Graph_u=Graph_u, Prec_eps=Prec_eps, H=H)
@@ -150,8 +150,8 @@ def test_that_enif_equals_kalman_under_exact_precision_and_H(n, p, phi):
 
     # EnIF high-level API with known precision
     gtmap = EnIF(Prec_u=Prec_u, Prec_eps=Prec_eps, H=H)
-    gtmap.fit(U, verbose_level=4)
-    U_posterior_enif = gtmap.transport(U, Y, d, seed=42, verbose_level=10)
+    gtmap.fit(U)
+    U_posterior_enif = gtmap.transport(U, Y, d, seed=42)
 
     # Create Kalman update -- use same noise
     eps = gtmap.generate_observation_noise(n, seed=42)


### PR DESCRIPTION
- Remove the verbose_level argument used in many functions.
- Replace calls to print with logging.
- In one instance, logic related to "updating ordering knowledge" (setting self.Graph_C, etc) was dependent upon the verbosity level. This dependency is removed - the internal state is now always updated. Logging/printing levels should not have computational side effects or update object state in this way.

Since this changes the public API, it is not backwards compatible.