### PR TITLE
Ensure correct return type

### DIFF
--- a/graphite_maps/precision_estimation.py
+++ b/graphite_maps/precision_estimation.py
@@ -444,10 +444,8 @@ def fit_precision_cholesky_approximate(
         G=G_expanded,
         use_tqdm=use_tqdm,
     )
-
     Prec_approx = C.T @ C
-
-    return Prec_approx
+    return Prec_approx.tocsc()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Function type hint says CSC, and this is what cholesky needs too. Ensuring this removes a warning where cholesky routine converts type, and ensure simplementation matches declared type