### PR TITLE
Use CG instead of bicgstab

### DIFF
--- a/graphite_maps/enif.py
+++ b/graphite_maps/enif.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy as sp
 from numpy.typing import NDArray
 from scipy.sparse import diags_array, sparray
-from scipy.sparse.linalg import bicgstab
+from scipy.sparse.linalg import LinearOperator, cg
 from sksparse.cholmod import cholesky
 from tqdm import tqdm
 
@@ -425,6 +425,14 @@ class EnIF:
 
         # === Iterative solution ===
         if iterative:
+            # Jacobi preconditioner: M ~= inv(diag(P_ss))
+            inv_diag_P_ss = 1.0 / P_ss.diagonal()
+            M = LinearOperator(
+                shape=P_ss.shape,
+                matvec=lambda x: inv_diag_P_ss * x,
+                dtype=P_ss.dtype,
+            )
+
             desc = "Mapping data to moment parametrisation realization-by-realization"
 
             for i in tqdm(range(U.shape[0]), desc=desc):
@@ -433,7 +441,7 @@ class EnIF:
                 else:
                     rhs = updated_canonical[i, s]
 
-                x_updated, _ = bicgstab(P_ss, rhs)
+                x_updated, _ = cg(P_ss, rhs, M=M)
                 U[i, s] = x_updated
 
             return U


### PR DESCRIPTION
Not sure why bicgstab was used here. The matrix is symmetric, so might as well use CG (with a preconditioner too?) - its a bit faster and the common choice for sym pos def matrices.