### PR TITLE
Sampling arbitrary Precision matrices, not just diagonal

### DIFF
--- a/graphite_maps/utils.py
+++ b/graphite_maps/utils.py
@@ -63,7 +63,7 @@ def generate_gaussian_noise(
     # General case: precision matrix is not diagonal
     z = rng.normal(size=(m, n))
 
-    # The simplest, but naive, way to sampel is to compute:
+    # The simplest, but naive, way to sample is to compute:
     # cov = np.linalg.inv(Prec.todense())
     # C = np.linalg.cholesky(cov)
     # assert np.allclose(C @ C.T, cov)

--- a/graphite_maps/utils.py
+++ b/graphite_maps/utils.py
@@ -1,8 +1,10 @@
 import logging
 
 import numpy as np
+import scipy as sp
 from numpy.typing import NDArray
 from scipy.sparse import sparray
+from sksparse.cholmod import cholesky
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -25,28 +27,55 @@ def generate_gaussian_noise(
     -------
     np.ndarray
         The Gaussian noise array of shape (n, m), where Prec has shape (m, m).
+
+    Examples
+    --------
+    >>> F = sp.sparse.random_array(shape=(6, 6), density=0.3, random_state=42)
+    >>> Prec = sp.sparse.csc_array(F.T @ F + np.diag([1, 2, 4, 8, 16, 32]))
+    >>> generate_gaussian_noise(n=3, Prec=Prec, seed=1).round(2)
+    array([[ 0.35,  0.19, -0.33, -0.19, -0.32,  0.1 ],
+           [ 0.82,  0.02, -0.07,  0.2 ,  0.23,  0.01],
+           [ 0.33,  0.36, -0.19,  0.11,  0.11, -0.05]])
+
+    >>> Prec = sp.sparse.diags_array(Prec.diagonal())
+    >>> generate_gaussian_noise(n=3, Prec=Prec, seed=2).round(2)
+    array([[ 0.19, -1.6 , -0.14, -0.19, -0.08, -0.02],
+           [-0.52,  1.18,  0.32,  0.34, -0.2 ,  0.09],
+           [-0.41,  0.75,  0.12, -0.11,  0.11, -0.1 ]])
     """
     if n < 1:
         raise ValueError(f"`n` should be g.e. 1, got {n}")
 
     m = Prec.shape[0]
     rng = np.random.default_rng(seed)
-    eps = rng.normal(
-        loc=0,
-        scale=np.sqrt(np.linalg.inv(Prec.toarray()).diagonal()),
-        size=(n, m),
-    )
+    z = rng.normal(size=(m, n))
 
-    # standard_normal_samples = rng.normal(size=(n, m))
-    # cholesky_factor = cholesky(Prec)
+    # If precision matrix is diagonal
+    row_idx, col_idx, _ = sp.sparse.find(Prec)
+    if np.all(row_idx == col_idx):
+        # Scale is the standard deviations. diag(Prec) = 1 / variances
+        scale = np.sqrt(1 / Prec.diagonal())
+        return (z * scale[:, None]).T
 
-    # Transform the samples using the inverse Cholesky factor
-    # This transformation results in samples from N(0, Prec^-1)
-    # eps = cholesky_factor.solve_A(standard_normal_samples.T).T
+    # General case: precision matrix is not diagonal
 
-    assert eps.shape == (n, m), "Sampling returns wrong size"
+    # The simplest, but naive, way to sampel is to compute:
+    # cov = np.linalg.inv(Prec.todense())
+    # C = np.linalg.cholesky(cov)
+    # assert np.allclose(C @ C.T, cov)
+    # return (np.linalg.cholesky(cov) @ z).T
 
-    log.info("Sampling with seed=%s", seed)
-    log.info("Sampled Gaussian noise with shape=%s", eps.shape)
+    # Suppose C @ C.T = Cov, then our samples are eps = C @ z.
+    # If we take cholesky of Prec, we obtain L @ L.T = P @ Prec @ P.T.
+    # Rearrange to (P.T @ L) @ (P.T @ L).T = Prec, then take inverse
+    # to see that C = inv((P.T @ L).T). Thus the equation eps = C @ z
+    # becomes the system (P.T @ L).T @ eps = z, which we solve for eps below
+    factor = cholesky(Prec)
+    v = factor.solve_Lt(z, use_LDLt_decomposition=False)
+    return factor.apply_Pt(v).T
 
-    return eps
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main(args=[__file__, "--doctest-modules", "-v"])

--- a/graphite_maps/utils.py
+++ b/graphite_maps/utils.py
@@ -39,25 +39,29 @@ def generate_gaussian_noise(
 
     >>> Prec = sp.sparse.diags_array(Prec.diagonal())
     >>> generate_gaussian_noise(n=3, Prec=Prec, seed=2).round(2)
-    array([[ 0.19, -1.6 , -0.14, -0.19, -0.08, -0.02],
-           [-0.52,  1.18,  0.32,  0.34, -0.2 ,  0.09],
-           [-0.41,  0.75,  0.12, -0.11,  0.11, -0.1 ]])
+    array([[ 0.19, -0.34, -0.17, -0.84,  0.45,  0.2 ],
+           [-0.33,  0.51,  0.12, -0.19,  0.24, -0.05],
+           [-0.33, -0.52,  0.19, -0.03,  0.14, -0.1 ]])
     """
     if n < 1:
         raise ValueError(f"`n` should be g.e. 1, got {n}")
 
     m = Prec.shape[0]
     rng = np.random.default_rng(seed)
-    z = rng.normal(size=(m, n))
 
     # If precision matrix is diagonal
     row_idx, col_idx, _ = sp.sparse.find(Prec)
     if np.all(row_idx == col_idx):
         # Scale is the standard deviations. diag(Prec) = 1 / variances
         scale = np.sqrt(1 / Prec.diagonal())
-        return (z * scale[:, None]).T
+        return rng.normal(
+            loc=0,
+            scale=scale,
+            size=(n, m),
+        )
 
     # General case: precision matrix is not diagonal
+    z = rng.normal(size=(m, n))
 
     # The simplest, but naive, way to sampel is to compute:
     # cov = np.linalg.inv(Prec.todense())

--- a/tests/test_enif.py
+++ b/tests/test_enif.py
@@ -79,8 +79,8 @@ def test_snapshot_highlevel():
     U_posterior = gtmap.transport(U, Y, d, seed=42)
 
     # Check result
-    desired = np.array([0.039102, -0.491275, -0.913188, -0.318065, -1.603981])
-    np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-5)
+    desired = np.array([0.01311213, -0.40208624, -0.49277274, -0.29639235, -1.84713641])
+    np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-6)
 
     # Call the high-level API, using "Prec_u"
     Prec_u = rng.normal(size=(n_params, n_params))
@@ -93,8 +93,10 @@ def test_snapshot_highlevel():
     gtmap.fit(U, ordering_method="natural")
     U_posterior = gtmap.transport(U, Y, d, seed=42)
 
-    desired = np.array([-0.042127, -0.421971, -0.94604, -0.261284, -1.491031])
-    np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-5)
+    desired = np.array(
+        [-0.03747837, -0.35764201, -0.78659938, -0.26586081, -1.53651656]
+    )
+    np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-6)
 
 
 @pytest.mark.parametrize("seed", range(10))
@@ -196,7 +198,7 @@ def test_snapshot_lowlevel():
     )
 
     desired_X_updated = np.array(
-        [0.12753731, -0.5230994, -0.79840529, -0.40772139, -1.4620114]
+        [-0.19630398, -0.27700102, -0.87434721, 0.03307433, -1.60668824]
     )
     np.testing.assert_allclose(np.diag(X_updated)[:5], desired_X_updated, rtol=1e-6)
 

--- a/tests/test_enif.py
+++ b/tests/test_enif.py
@@ -79,8 +79,8 @@ def test_snapshot_highlevel():
     U_posterior = gtmap.transport(U, Y, d, seed=42)
 
     # Check result
-    desired = np.array([0.01311213, -0.40208624, -0.49277274, -0.29639235, -1.84713641])
-    np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-6)
+    desired = np.array([0.039102, -0.491275, -0.913188, -0.318065, -1.603981])
+    np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-5)
 
     # Call the high-level API, using "Prec_u"
     Prec_u = rng.normal(size=(n_params, n_params))
@@ -93,10 +93,8 @@ def test_snapshot_highlevel():
     gtmap.fit(U, ordering_method="natural")
     U_posterior = gtmap.transport(U, Y, d, seed=42)
 
-    desired = np.array(
-        [-0.03747837, -0.35764201, -0.78659938, -0.26586081, -1.53651656]
-    )
-    np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-6)
+    desired = np.array([-0.042127, -0.421971, -0.94604, -0.261284, -1.491031])
+    np.testing.assert_allclose(np.diag(U_posterior)[:5], desired, rtol=1e-5)
 
 
 @pytest.mark.parametrize("seed", range(10))
@@ -198,7 +196,7 @@ def test_snapshot_lowlevel():
     )
 
     desired_X_updated = np.array(
-        [-0.19630398, -0.27700102, -0.87434721, 0.03307433, -1.60668824]
+        [0.12753731, -0.5230994, -0.79840529, -0.40772139, -1.4620114]
     )
     np.testing.assert_allclose(np.diag(X_updated)[:5], desired_X_updated, rtol=1e-6)
 


### PR DESCRIPTION
In the original code, a sparse 2D array was allowed everywhere. However, when sampling the code threw away everything except the diagonal. So anything except diagonal precision matrices would actually silently fail.

The original code also computes in an unfortunate order: first invert a dense 2D matrix, then retrieve the diagonal. In the diagonal case, we can just extract the diagonal and do scalar inversion instead of a dense matrix inversion.

Closes #122 